### PR TITLE
implementation of delimited sequence schema

### DIFF
--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -515,6 +515,33 @@
     (invalid! schema ["user1" 42 42])
     (valid! schema ["user2" 41]) ))
 
+(deftest delimited-test
+  (testing "delimited schema checks both halves of sequence"
+    (let [schema (s/delimited [s/Int] :delimiter [s/Str])]
+      (valid! schema [1 2 :delimiter "a" "b"])
+      (valid! schema [:delimiter "a" "b"])
+      (valid! schema [1 2 :delimiter])
+      (valid! schema [:delimiter])
+      (invalid! schema [1 2 "a" "b"])
+      (invalid! schema [1 :delimiter 2 "a" "b"])
+      (invalid! schema [1 2 "a" :delimiter "b"])))
+
+  (testing "non-greedy delimited uses first instance of delimiter"
+    (let [schema (s/delimited [s/Int] :delimiter [s/Keyword])]
+      (valid! schema [1 2 :delimiter :x :y])
+      (valid! schema [1 2 :delimiter :x :delimiter :y])
+      (let [schema (s/delimited [s/Keyword] :delimiter [s/Int])]
+        (valid! schema [:a :b :delimiter 1 2])
+        (invalid! schema [:a :delimiter :b :delimiter 1 2]))))
+
+  (testing "greedy delimited uses last instance of delimiter"
+    (let [schema (s/delimited-greedy [s/Int] :delimiter [s/Keyword])]
+      (valid! schema [1 2 :delimiter :x :y])
+      (invalid! schema [1 2 :delimiter :x :delimiter :y])
+      (let [schema (s/delimited-greedy [s/Keyword] :delimiter [s/Int])]
+        (valid! schema [:a :b :delimiter 1 2])
+        (valid! schema [:a :delimiter :b :delimiter 1 2])))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Record Schemas
 


### PR DESCRIPTION
Implements delimited sequence schema for matching delimited sequences.

An example of a delimited sequence is: `(s/delimited [s/Int] :delimiter [s/Str])` which would match `[1 2 3 4 :delimiter "a" "b" "c"]`. Here there is a sequence of integers, a single delimiter, and then a sequence of strings all concatted into the same vector. The matching is implemented by splitting the sequence on the delimiter, and then recursively matching each side. In the event of multiple delimiters, there is a flag to determine whether to match on the first or last occurrence.

The motivation is to make schema rich enough to express the sequences used in clojure's binding forms, such as: `(let  [[a b :as args] [1 2]] ...)`. In this binding, the `:as` is the delimiter, and the left schema is a sequence of symbols, the right schema is a single symbol `[(s/one clojure.lang.Symbol "binding name")]`.