### PR TITLE
Change how protocol is extended to primitive hints:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.5
+ * Make primitive schemas work better in some cases under partial AOT compilation
+	
 ## 0.3.3
  * Fix bug in `defschema` which clobbered metadata, breaking `s/protocol` in Clojure in 0.3.2.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Clojure(Script) library for declarative data description and validation.
 
-Leiningen dependency (Clojars): `[prismatic/schema "0.3.4"]`. [Latest codox API docs](http://prismatic.github.io/schema).
+Leiningen dependency (Clojars): `[prismatic/schema "0.3.5"]`. [Latest codox API docs](http://prismatic.github.io/schema).
 
 **This is an alpha release. The API and organizational structure are
 subject to change. Comments and contributions are much appreciated.**

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -200,7 +200,7 @@
 #+clj
 (do
   (defmacro extend-primitive [cast-sym class-sym]
-    (let [qualified-cast-sym (symbol (str "clojure.core$" (name cast-sym)))]
+    (let [qualified-cast-sym `(class @(resolve '~cast-sym))]
       `(extend-protocol Schema
          ~qualified-cast-sym
          (walker [this#]


### PR DESCRIPTION
 - Class name and going through the var should be equivalent in most cases
 - In some cases with AOT, they can resolve to different classes
 - The latter one seems to be in line with what primitive hints will resolve to in user code