### PR TITLE
Support java.util.List in vector schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.6
+ * Support java.util.List instances as valid data for sequence schemas
+ 
 ## 0.3.5
  * Make primitive schemas work better in some cases under partial AOT compilation
 	

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Clojure(Script) library for declarative data description and validation.
 
-Leiningen dependency (Clojars): `[prismatic/schema "0.3.5"]`. [Latest codox API docs](http://prismatic.github.io/schema).
+Leiningen dependency (Clojars): `[prismatic/schema "0.3.6"]`. [Latest codox API docs](http://prismatic.github.io/schema).
 
 **This is an alpha release. The API and organizational structure are
 subject to change. Comments and contributions are much appreciated.**

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -814,7 +814,7 @@
           multi-walker (when multi (subschema-walker multi))
           err-conj (utils/result-builder (clojure.core/fn [m] (vec (repeat (count m) nil))))]
       (clojure.core/fn [x]
-        (or (when-not (or (nil? x) (sequential? x))
+        (or (when-not (or (nil? x) (sequential? x) #+clj (instance? java.util.List x))
               (macros/validation-error this x (list 'sequential? (utils/value-name x))))
             (loop [single-walkers single-walkers x x out []]
               (if-let [[^One first-single single-walker] (first single-walkers)]

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -515,6 +515,17 @@
     (invalid! schema ["user1" 42 42])
     (valid! schema ["user2" 41]) ))
 
+#+clj
+(deftest java-list-test
+  (let [schema [s/Str]]
+    (valid! schema (java.util.ArrayList. ["hi" "bye"]))
+    (invalid! schema (java.util.ArrayList. [1 2]))
+    (valid! schema (java.util.LinkedList. ["hi" "bye"]))
+    (invalid! schema (java.util.LinkedList. [1 2]))
+    (valid! schema java.util.Collections/EMPTY_LIST)
+    (invalid! schema java.util.Collections/EMPTY_MAP)
+    (invalid! schema #{"hi" "bye"})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Record Schemas
 


### PR DESCRIPTION
Classes like java.util.ArrayList do not currently pass [] schemas because
they don't pass `sequential?`. However, since they are seqable, we are able
to walk the schema as one would expect. Expands the conditional to accept
instances of java.util.List.