### PR TITLE
Allow use of schema.core without :includes-macros in Cljs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
-                                  [org.clojure/clojurescript "0.0-2665"]
+                                  [org.clojure/clojurescript "0.0-2760"]
                                   [org.clojure/tools.nrepl "0.2.5"]]
                    :plugins [[com.keminglabs/cljx "0.6.0" :exclusions [org.clojure/clojure]]
                              [codox "0.8.8"]

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -80,7 +80,8 @@
    [clojure.string :as str]
    #+clj [schema.macros :as macros]
    [schema.utils :as utils])
-  #+cljs (:require-macros [schema.macros :as macros]))
+  #+cljs (:require-macros [schema.macros :as macros]
+                          schema.core))
 
 #+clj (set! *warn-on-reflection* true)
 

--- a/test/clj/schema/test_macros.clj
+++ b/test/clj/schema/test_macros.clj
@@ -2,7 +2,7 @@
   "Macros to help cross-language testing of schemas."
   (:require
    clojure.test
-   [schema.core :as s :include-macros true]
+   [schema.core :as s]
    [schema.macros :as sm]))
 
 (defmacro valid!

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -14,7 +14,7 @@
   (:require
    clojure.data
    [schema.utils :as utils]
-   [schema.core :as s :include-macros true]
+   [schema.core :as s]
    #+clj [schema.macros :as macros]
    #+cljs cemerick.cljs.test))
 


### PR DESCRIPTION
Hi,

From version 2755 ClojureScript has supported loading macros automatically if the required ns (e.g. `schema.core`) loads it's own macros using `:require-macros`.

However, there is a small problem. Upgrading the ClojureScript dependency breaks a test: https://github.com/Prismatic/schema/blob/master/test/cljx/schema/core_test.cljx#L984