### PR TITLE
defschema with :full-name meta-data

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -969,13 +969,21 @@
   "Returns the name of a schema attached via schema-with-name (or defschema)."
   (-> schema meta :name))
 
+(clojure.core/defn full-schema-name [schema]
+  "Returns the full name of a schema attached via defschema."
+  (-> schema meta :full-name))
+
 (defmacro defschema
   "Convenience macro to make it clear to reader that body is meant to be used as a schema.
    The name of the schema is recorded in the metadata."
   ([name form]
      `(defschema ~name "" ~form))
   ([name docstring form]
-     `(def ~name ~docstring (schema-with-name ~form '~name))))
+   (let [full-name (symbol (str (str *ns*) "/" name))]
+     `(def ~name ~docstring
+        (vary-meta
+          (schema-with-name ~form '~name)
+          assoc :full-name '~full-name)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -969,9 +969,9 @@
   "Returns the name of a schema attached via schema-with-name (or defschema)."
   (-> schema meta :name))
 
-(clojure.core/defn full-schema-name [schema]
-  "Returns the full name of a schema attached via defschema."
-  (-> schema meta :full-name))
+(clojure.core/defn schema-ns [schema]
+  "Returns the namespace of a schema attached via defschema."
+  (-> schema meta :ns))
 
 (defmacro defschema
   "Convenience macro to make it clear to reader that body is meant to be used as a schema.
@@ -979,11 +979,10 @@
   ([name form]
      `(defschema ~name "" ~form))
   ([name docstring form]
-   (let [full-name (symbol (str (str *ns*) "/" name))]
      `(def ~name ~docstring
         (vary-meta
           (schema-with-name ~form '~name)
-          assoc :full-name '~full-name)))))
+          assoc :ns '~(.getName *ns*)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -982,7 +982,7 @@
      `(def ~name ~docstring
         (vary-meta
           (schema-with-name ~form '~name)
-          assoc :ns '~(.getName *ns*)))))
+          assoc :ns '~(ns-name *ns*)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1232,25 +1232,17 @@
 
 (deftest test-defschema
   (is (= 'TestFoo (:name (meta TestFoo))))
-  (is (= 'schema.core-test/TestFoo (:full-name (meta TestFoo)))))
+  (is (= 'schema.core-test (:ns (meta TestFoo)))))
 
 (deftest schema-with-name-test
   (let [schema (s/schema-with-name {:baz s/Num} 'Baz)]
     (valid! schema {:baz 123})
     (invalid! schema {:baz "abc"})
     (is (= 'Baz (s/schema-name schema)))
-    (is (=  nil (s/full-schema-name schema)))))
+    (is (=  nil (s/schema-ns schema)))))
 
 (deftest schema-name-test
   (is (= 'TestFoo (s/schema-name TestFoo))))
 
-(deftest full-schema-name-test
-  (is (= 'schema.core-test/TestFoo (s/full-schema-name TestFoo))))
-
-(s/defschema TestBar "BarTest" {:foo s/Str})
-
-#+clj ;; no Var meta-data on cljs
-(deftest defschema-var-metadata
-  (let [{:keys [line doc]} (-> TestBar s/full-schema-name resolve meta)]
-    (is (= line 1250))
-    (is (= doc "BarTest"))))
+(deftest schema-ns-test
+  (is (= 'schema.core-test (s/schema-ns TestFoo))))

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1231,13 +1231,26 @@
 (s/defschema TestFoo {:bar s/Str})
 
 (deftest test-defschema
-  (is (= 'TestFoo (:name (meta TestFoo)))))
+  (is (= 'TestFoo (:name (meta TestFoo))))
+  (is (= 'schema.core-test/TestFoo (:full-name (meta TestFoo)))))
 
 (deftest schema-with-name-test
   (let [schema (s/schema-with-name {:baz s/Num} 'Baz)]
     (valid! schema {:baz 123})
     (invalid! schema {:baz "abc"})
-    (is (= 'Baz (s/schema-name schema)))))
+    (is (= 'Baz (s/schema-name schema)))
+    (is (=  nil (s/full-schema-name schema)))))
 
 (deftest schema-name-test
   (is (= 'TestFoo (s/schema-name TestFoo))))
+
+(deftest full-schema-name-test
+  (is (= 'schema.core-test/TestFoo (s/full-schema-name TestFoo))))
+
+(s/defschema TestBar "BarTest" {:foo s/Str})
+
+#+clj ;; no Var meta-data on cljs
+(deftest defschema-var-metadata
+  (let [{:keys [line doc]} (-> TestBar s/full-schema-name resolve meta)]
+    (is (= line 1250))
+    (is (= doc "BarTest"))))


### PR DESCRIPTION
`defschema` now adds `:full-name` metadata with fully-qualified schema-name. One can retrieve the full-name with helper function `full-schema-name`. Resolves #210.

This also creates two nice bonuses:

1) one can resolve the `:full-name` and get the Schema Var (in the Clojure-side only) and fetch all the extra meta-data out that: docstring, line-number, file etc. Great for documentation. See `schema.core-test.cljx` for details.

2) one **could** create tooling with this to check whether Schema definitions and linked Schemas are in sync:

```clojure

;; defina a schema in ns a
(ns a)
(require '[schema.core :as s])
(s/defschema Kikka {:a s/Str})
; => #'a/Kikka

;; define a schema in ns b using schema from a
(ns b)
(require '[schema.core :as s])
(require 'a)
(s/defschema Kukka {:kikka a/Kikka})
; => #'b/Kukka

;; modify the original schema
(ns a)
(s/defschema Kikka {:a s/Any})
; => #'a/Kikka

;; the schema-names are still the same, but the linked value is out of sync
(ns b)
(= (s/schema-name a/Kikka) 
   (s/schema-name (:kikka Kukka)))
; => true

(= a/Kikka
   (:kikka Kukka))
; => false
```
