### PR TITLE
extends Schema for IPersistentMap instead of APersistentMap

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -744,7 +744,7 @@
   (into {} (for [[k v] this] (vec (next (explain (map-entry k v)))))))
 
 (extend-protocol Schema
-  #+clj clojure.lang.APersistentMap
+  #+clj clojure.lang.IPersistentMap
   #+cljs cljs.core.PersistentArrayMap
   (walker [this] (map-walker this))
   (explain [this] (map-explain this))


### PR DESCRIPTION
This PR gives wider support for custom Map-implementations. Not all Maps are extending the abstract `APersistentMap`, one is these is the `flatland.ordered.map.OrderedMap`.

with current version:

```clojure
lein try prismatic/schema "0.4.2" org.flatland/ordered

(require '[schema.core :as s])
(require '[flatland.ordered.map :as m])
(satisfies? s/Schema (m/ordered-map {}))
; => false
``` 

with this modification:
```clojure
lein try prismatic/schema "0.4.3-SNAPSHOT" org.flatland/ordered

(require '[schema.core :as s])
(require '[flatland.ordered.map :as m])
(satisfies? s/Schema (m/ordered-map {}))
; => true
```

related to https://github.com/metosin/compojure-api/issues/95