### PR TITLE
Configurable maximum length for values in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Thus, each time you invoke `stamped-names`, Schema will perform validation.
 
 To reduce generated code size, you can use the `*assert*` flag and `set-compile-fn-validation!` functions to control when validation code is generated ([details](https://github.com/Prismatic/schema/blob/master/src/clj/schema/macros.clj#L181)).
 
+Schema will attempt to reduce the verbosity of its output by restricting the size of values that fail validation to 19 characters.  If a value exceeds this, it will be replaced by the name of its class.  You can adjust this size limitation by calling `set-max-value-length!`.
+
 Finally, we use validation with coercion for API inputs and outputs.  See the coercion section below for details.
 
 ## More examples

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1257,3 +1257,8 @@
 
 #+clj
 (set! *warn-on-reflection* false)
+
+(clojure.core/defn set-max-value-length!
+  "Sets the maximum length of value to be output before it is contracted to a prettier name."
+  [max-length]
+  (reset! utils/max-value-length max-length))

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -30,11 +30,13 @@
 (defn format* [fmt & args]
   (apply #+clj format #+cljs gstring/format fmt args))
 
+(def max-value-length (atom 19))
+
 (defn value-name
   "Provide a descriptive short name for a value."
   [value]
   (let [t (type-of value)]
-    (if (< (count (str value)) 20)
+    (if (<= (count (str value)) @max-value-length)
       value
       (symbol (str "a-" #+clj (.getName ^Class t) #+cljs t)))))
 


### PR DESCRIPTION
Sometimes it's useful to be able to see the value that failed validation in the output, but the hard-coded maximum length of 19 characters (< 20) can prevent this.  This PR makes that value configurable using the `set-max-value-length!` function in core, by changing the value of an atom in utils.  The atom defaults to 19, so this is not a breaking change.