### PR TITLE
queue schemas

### DIFF
--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -460,6 +460,18 @@
     (invalid! schema #{#{[3 4]}})
     (invalid! schema #{[[3 4]]})))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Queue Schemas
+
+(deftest queue-test
+  (testing "queues of simple values"
+    (let [schema (s/queue s/Int)]
+      (valid! schema (s/as-queue []))
+      (valid! schema (s/as-queue [1]))
+      (valid! schema (s/as-queue [1 2 3 4]))
+      (invalid! schema [1 2 3])
+      (invalid! schema (s/as-queue [1 :a 3])))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Sequence Schemas


### PR DESCRIPTION
This commit adds schema support for `PersistentQueue`. The following creates a schema that matches a persistent queue whose elements (if any) match the sub-schema `Int`:

```clojure
   (require [core.schema :as s])
   (def int-queue (s/queue s/Int))
```