### PR TITLE
Making string-coercion-matcher more consistent with json-coercion-matcher

### DIFF
--- a/src/cljx/schema/coerce.cljx
+++ b/src/cljx/schema/coerce.cljx
@@ -130,4 +130,5 @@
      and long and doubles (JVM only) from strings."
   [schema]
   (or (+string-coercions+ schema)
-      (keyword-enum-matcher schema)))
+      (keyword-enum-matcher schema)
+      (set-matcher schema)))

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -62,8 +62,8 @@
 
 (deftest string-coercer-test
   (let [coercer (coerce/coercer Generic coerce/string-coercion-matcher)]
-    (is (= {:b true :i 1 :n 3.0 :s "asdf" :k1 {1 :hi} :k2 :bye :e :a :u #uuid "550e8400-e29b-41d4-a716-446655440000"}
-           (coercer {:b "true" :i "1" :n "3.0" :s "asdf" :k1 {"1" "hi"} :k2 "bye" :e "a" :u "550e8400-e29b-41d4-a716-446655440000"})))
+    (is (= {:b true :i 1 :n 3.0 :s "asdf" :k1 {1 :hi} :k2 :bye :e :a :u #uuid "550e8400-e29b-41d4-a716-446655440000" :set #{:a :b}}
+           (coercer {:b "true" :i "1" :n "3.0" :s "asdf" :k1 {"1" "hi"} :k2 "bye" :e "a" :u "550e8400-e29b-41d4-a716-446655440000" :set ["a" "a" "b"]})))
     (is (= #{:i} (err-ks (coercer {:i "1.1"})))))
 
   #+clj (testing "jvm specific"


### PR DESCRIPTION
I see that `json-coercion-matcher` adds `keyword-enum-matcher` and `set-matcher` to `+json-coercions+`.

Also `+string-coercions+` includes `+json-coercions+`, while `string-coercion-matcher` adds `keyword-enum-matcher` to `+string-coercions+` but omits `set-matcher`.

This change brings `string-coercion-matcher` more into line with `json-coercion-matcher`.

Thanks