### PR TITLE
Declarative schema specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
  * **BREAKING** Changes to the core Schema protocol will break existing third-party schema tooling and schema types.
  * **BREAKING** Records coerced to an ordinary (non-record) map schema are now converted to maps, rather than retaining their record type.
  * **BREAKING** `s/either` no longer works with coercion.  We recommend switching to `s/conditional` or other options.
- * **Deprecate** `s/both` in favor of new `s/constrained`.
+ * **Deprecate** `s/both` in favor of improved `s/conditional`.
  * `s/pred` can more intelligently guess the predicate name
  * `record` schemas can now coerce values to corresponding record types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.0.0-alpha1
- * New schema backend, which is faster, simpler, and more declarative, enabling more applications and simplifying tooling.  Users of built-in schema types should experience very little or no breakage, but tooling or custom schema types will need to be updated.
+ * New schema backend, which is faster, simpler, and more declarative, enabling more applications and simplifying tooling.  Users of built-in schema types should experience very little or no breakage, but tooling or custom schema types will need to be updated.   As a concrete example of an application that's enabled, schema now experimentally supports test-check style generation from schemas.
  * **BREAKING** Changes to the core Schema protocol will break existing third-party schema tooling and schema types.
  * **BREAKING** Records coerced to an ordinary (non-record) map schema are now converted to maps, rather than retaining their record type.
  * **BREAKING** `s/either` no longer works with coercion.  We recommend switching to `s/conditional` or other options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-alpha1
+ * New schema backend, which is faster, simpler, and more declarative, enabling more applications and simplifying tooling.  Users of built-in schema types should experience very little or no breakage, but tooling or custom schema types will need to be updated.
+ * **BREAKING** Changes to the core Schema protocol will break existing third-party schema tooling and schema types.
+ * **BREAKING** Records coerced to an ordinary (non-record) map schema are now converted to maps, rather than retaining their record type.
+ * **BREAKING** `s/either` no longer works with coercion.  We recommend switching to `s/conditional` or other options.
+ * **Deprecate** `s/both` in favor of new `s/constrained`.
+ * `s/pred` can more intelligently guess the predicate name
+ * `record` schemas can now coerce values to corresponding record types.
+
 ## 0.4.4
  * Fix ClojureScript warnings about `map->Record` constructors being redefined.
  * Add queue schemas

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject prismatic/schema "0.4.5-SNAPSHOT"
+(defproject prismatic/schema "1.0.0-SNAPSHOT"
   :description "Clojure(Script) library for declarative data description and validation"
   :url "http://github.com/prismatic/schema"
   :license {:name "Eclipse Public License"
@@ -6,7 +6,8 @@
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "0.0-2760"]
-                                  [org.clojure/tools.nrepl "0.2.5"]]
+                                  [org.clojure/tools.nrepl "0.2.5"]
+                                  [org.clojure/test.check "0.5.7"]]
                    :plugins [[com.keminglabs/cljx "0.6.0" :exclusions [org.clojure/clojure]]
                              [codox "0.8.8"]
                              [lein-cljsbuild "1.0.5"]

--- a/src/clj/schema/experimental/complete.clj
+++ b/src/clj/schema/experimental/complete.clj
@@ -1,0 +1,42 @@
+(ns schema.experimental.complete
+  "Experimental support for 'completing' partial values to match a target schema,
+   e.g. for tests where only part of an object is important."
+  (:require
+   [clojure.test.check.generators :as check-generators]
+   [schema.core :as s]
+   [schema.spec.core :as spec]
+   [schema.experimental.generators :as generators]
+   schema.spec.collection
+   schema.spec.leaf
+   schema.spec.variant))
+
+(defprotocol Completer
+  (completer [s]))
+
+(def +missing+ ::missing)
+
+(extend-protocol Completer
+  schema.spec.leaf.LeafSpec
+  (completer [s]
+    (let [g (generators/leaf-generator s)]
+      (fn [x] (if (= x +missing+) (last (check-generators/sample g 5)) x))))
+
+  schema.spec.variant.VariantSpec
+  (completer [s] (s/checker s))
+
+  schema.spec.collection.CollectionSpec
+  (completer [s]
+    (let [c (s/checker s)
+          g (generators/generator s {:subschema-generator generators/schema-generator})]
+      (fn [x]
+        (if-not (= +missing+ x)
+          (if (instance? clojure.lang.APersistentMap s) ;; todo: pluggable
+            (c (merge (last (check-generators/sample g 5)) x))
+            (c x))
+          (last (check-generators/sample g 5)))))))
+
+(defn schema-completer [s]
+  (completer (s/spec s)))
+
+(defn sample-datum [s x]
+  ((spec/run-checker schema-completer true s) x))

--- a/src/clj/schema/experimental/generators.clj
+++ b/src/clj/schema/experimental/generators.clj
@@ -1,0 +1,81 @@
+(ns schema.experimental.generators
+  "(Very) experimental support for compiling schemas to test.check generators.
+   TODO: support for more types, extensible leaf generators, constraints, etc.
+   Not currently cljx only because was running into issues with test.check."
+  (:require
+   [clojure.test.check.generators :as generators]
+   [schema.spec.core :as spec]
+   schema.spec.collection
+   schema.spec.leaf
+   schema.spec.variant
+   [schema.core :as s]
+   [schema.macros :as macros]))
+
+(defn g-by [f & args]
+  (generators/fmap
+   (partial apply f)
+   (apply generators/tuple args)))
+
+(defn g-apply-by [f args]
+  (generators/fmap f (apply generators/tuple args)))
+
+(defn- sub-generator
+  [{:keys [schema]}
+   {:keys [subschema-generator ^java.util.Map cache] :as params}]
+  (spec/with-cache cache schema
+    (fn [d] (generators/make-gen (fn [r s] (generators/call-gen @d r s))))
+    (fn [] (subschema-generator schema params))))
+
+(defprotocol LeafGeneratable
+  (leaf-generator [s] "return a generator for s"))
+
+(extend-type nil
+  LeafGeneratable
+  (leaf-generator [x]
+    (cond
+     (= x s/Int) generators/int
+     (= x s/Str) generators/string-ascii
+     (= x s/Keyword) generators/keyword
+     :else (generators/return x))))
+
+(extend-type schema.core.EqSchema
+  LeafGeneratable
+  (leaf-generator [x]
+    (generators/return (:v x))))
+
+(defprotocol Generator
+  (generator [s params]))
+
+;; TODO: do stuff with guards and preconditions?
+(extend-protocol Generator
+  schema.spec.variant.VariantSpec
+  (generator [s params]
+    (generators/one-of
+     (for [o (macros/safe-get s :options)]
+       (sub-generator o params))))
+
+  schema.spec.collection.CollectionSpec
+  (generator [s params]
+    (generators/fmap
+     (comp (:constructor s) (partial apply concat))
+     (apply
+      generators/tuple
+      (for [{:keys [cardinality] :as e} (:elements s)]
+        (let [g (sub-generator e params)]
+          (case cardinality
+            :exactly-one (generators/fmap vector g)
+            :at-most-one (generators/one-of [(generators/return nil) (generators/fmap vector g)])
+            :zero-or-more (generators/vector g))))))))
+
+(defn schema-generator [s params]
+  (let [sp (s/spec s)]
+    (if (instance? schema.spec.leaf.LeafSpec sp)
+      (leaf-generator s)
+      (generator sp params))))
+
+(defn generate [s]
+  (generators/sample
+   (schema-generator
+    s
+    {:subschema-generator schema-generator
+     :cache (java.util.IdentityHashMap.)}) 10))

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -310,7 +310,8 @@
                            (do (assert! (symbol? k)
                                         "Non-symbol in record binding form: %s" k)
                                (extract-schema-form k))]))
-                 ~extra-key-schema?))
+                 ~extra-key-schema?)
+          ~(symbol (str 'map-> name)))
          :extra-validator-fn ~extra-validator-fn?))
        ~(let [map-sym (gensym "m")]
           `(if-cljs

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -426,9 +426,9 @@
     (variant/variant-spec
      spec/+no-precondition+
      (for [s schemas]
-       {:guard (complement (checker s))
+       {:guard (complement (checker s)) ;; since the guard determines which option we check against
         :schema s})
-     #(list 'matches-some-either-clause? %)))
+     #(list 'some-matching-either-clause? %)))
   (explain [this] (cons 'either (map explain schemas))))
 
 (clojure.core/defn either
@@ -500,7 +500,7 @@
      spec/+no-precondition+
      (for [[p s] preds-and-schemas]
        {:guard p :schema s})
-     #(list 'matches-some-condition? %))) ;; TODO: improve error message
+     #(list 'some-matching-condition? %))) ;; TODO: improve error message
   (explain [this]
     (->> preds-and-schemas
          (mapcat (clojure.core/fn [[pred schema]] [pred (explain schema)]))

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -79,7 +79,11 @@
   (:require
    [clojure.string :as str]
    #+clj [schema.macros :as macros]
-   [schema.utils :as utils])
+   [schema.utils :as utils]
+   [schema.spec.core :as spec :include-macros true]
+   [schema.spec.leaf :as leaf]
+   [schema.spec.variant :as variant]
+   [schema.spec.collection :as collection])
   #+cljs (:require-macros [schema.macros :as macros]
                           schema.core))
 
@@ -87,11 +91,11 @@
         (do (defprotocol CLJ1195Check
               (dummy-method [this]))
             (try
-             (eval '(extend-protocol CLJ1195Check nil
-                      (dummy-method [_])))
-             true
-             (catch RuntimeException _
-               false))))
+              (eval '(extend-protocol CLJ1195Check nil
+                                      (dummy-method [_])))
+              true
+              (catch RuntimeException _
+                false))))
 
 #+clj (when-not clj-1195-fixed?
         ;; don't exclude fn because of bug in extend-protocol
@@ -103,22 +107,9 @@
 ;;; Schema protocol
 
 (defprotocol Schema
-  (walker [this]
-    "Produce a function that takes [data], and either returns a walked version of data
-     (by default, usually just data), or a utils/ErrorContainer containing value that looks
-     like the 'bad' parts of data with ValidationErrors at the leaves describing the failures.
-
-     If this is a composite schema, should let-bind (subschema-walker sub-schema) for each
-     subschema outside the returned fn.  Within the returned fn, should break down data
-     into constituents, call the let-bound subschema walkers on each component, and then
-     reassemble the components into a walked version of the data (or an ErrorContainer
-     describing the validaiton failures).
-
-     Attempting to walk a value that already contains a utils/ErrorContainer produces undefined
-     behavior.
-
-     User code should never call `walker` directly.  Instead, it should call `start-walker`
-     below.")
+  (spec [this]
+    "A spec is a record of some type that expresses the structure of this schema
+     in a declarative and/or imperative way.  See schema.spec.* for examples.")
   (explain [this]
     "Expand this schema to a human-readable format suitable for pprinting,
      also expanding class schematas at the leaves.  Example:
@@ -134,34 +125,13 @@
     (prefer-method print-method schema.core.Schema java.util.Map)
     (prefer-method print-method schema.core.Schema clojure.lang.IPersistentMap))
 
-(def ^:dynamic subschema-walker
-  "The function to call within 'walker' implementations to create walkers for subschemas.
-   Can be dynamically bound (using start-walker below) to create different walking behaviors.
-
-   For the curious, implemented using dynamic binding rather than making walker take a
-   subschema-walker as an argument because some behaviors (e.g. recursive schema walkers)
-   seem to require mind-bending things like fixed-point combinators that way, but are
-   simple this way."
-  (clojure.core/fn [s]
-    (macros/error!
-     (str "Walking is unsupported outside of start-walker; "
-          "all composite schemas must eagerly bind subschema-walkers "
-          "outside the returned walker."))))
-
-(clojure.core/defn start-walker
-  "The entry point for creating walkers.  Binds the provided walker to subschema-walker,
-   then calls it on the provided schema.  For simple validation, pass walker as sub-walker.
-   More sophisticated behavior (coercion, etc), can be achieved by passing a sub-walker
-   that wraps walker with additional behavior."
-  [sub-walker schema]
-  (binding [subschema-walker sub-walker]
-    (subschema-walker schema)))
-
 (clojure.core/defn checker
   "Compile an efficient checker for schema, which returns nil for valid values and
    error descriptions otherwise."
   [schema]
-  (comp utils/error-val (start-walker (utils/memoize-id walker) schema)))
+  (comp utils/error-val
+        (spec/run-checker
+         (clojure.core/fn [s params] (spec/checker (spec s) params)) false schema)))
 
 (clojure.core/defn check
   "Return nil if x matches schema; otherwise, returns a value that looks like the
@@ -183,21 +153,23 @@
 ;; On the JVM, a Class itself is a schema. In JS, we treat functions as prototypes so any
 ;; function prototype checks objects for compatibility.
 
+(clojure.core/defn instance-precondition [s klass]
+  (spec/precondition
+   s
+   #+clj #(instance? klass %)
+   #+cljs #(and (not (nil? %))
+                (or (identical? klass (.-constructor %))
+                    (js* "~{} instanceof ~{}" % klass)))
+   #(list 'instance? klass %)))
+
 (extend-protocol Schema
   #+clj Class
   #+cljs function
-  (walker [this]
-    (let [class-walker (if-let [more-schema (utils/class-schema this)]
-                         ;; do extra validation for records and such
-                         (subschema-walker more-schema)
-                         identity)]
-      (clojure.core/fn [x]
-        (or (when #+clj (not (instance? this x))
-                  #+cljs (or (nil? x)
-                             (not (or (identical? this (.-constructor x))
-                                      (js* "~{} instanceof ~{}" x this))))
-                  (macros/validation-error this x (list 'instance? this (utils/value-name x))))
-            (class-walker x)))))
+  (spec [this]
+    (let [pre (instance-precondition this this)]
+      (if-let [class-schema (utils/class-schema this)]
+        (variant/variant-spec pre [{:schema class-schema}])
+        (leaf/leaf-spec pre))))
   (explain [this]
     (if-let [more-schema (utils/class-schema this)]
       (explain more-schema)
@@ -213,8 +185,8 @@
     (let [qualified-cast-sym `(class @(resolve '~cast-sym))]
       `(extend-protocol Schema
          ~qualified-cast-sym
-         (walker [this#]
-           (subschema-walker ~class-sym))
+         (spec [this#]
+           (variant/variant-spec spec/+no-precondition+ [{:schema ~class-sym}]))
          (explain [this#]
            '~cast-sym))))
 
@@ -246,22 +218,19 @@
   ;; loses type info, which makes this unusable in schema-fn.
   ;; http://dev.clojure.org/jira/browse/CLJ-1093
   Schema
-  (walker [this] identity)
+  (spec [this] (leaf/leaf-spec spec/+no-precondition+))
   (explain [this] 'Any))
 
 (def Any
   "Any value, including nil."
   (AnythingSchema. nil))
 
+
 ;;; eq (to a single allowed value)
 
 (clojure.core/defrecord EqSchema [v]
   Schema
-  (walker [this]
-          (clojure.core/fn [x]
-            (if (= v x)
-              x
-              (macros/validation-error this x (list '= v (utils/value-name x))))))
+  (spec [this] (leaf/leaf-spec (spec/precondition this #(= v %) #(list '= v %))))
   (explain [this] (list 'eq v)))
 
 (clojure.core/defn eq
@@ -269,18 +238,13 @@
   [v]
   (EqSchema. v))
 
+
 ;;; isa (a child of parent)
 
 (clojure.core/defrecord Isa [h parent]
   Schema
-  (walker [this]
-          (clojure.core/fn [child]
-            (if (or (and h (isa? h child parent))
-                    (isa? child parent))
-              child
-              (macros/validation-error this child (list 'isa? child parent)))))
-  (explain [this]
-           (list 'isa? parent)))
+  (spec [this] (leaf/leaf-spec (spec/precondition this #(isa? h % parent) #(list 'isa? % parent))))
+  (explain [this] (list 'isa? parent)))
 
 (clojure.core/defn isa
   "A value that must be a child of parent."
@@ -294,11 +258,7 @@
 
 (clojure.core/defrecord EnumSchema [vs]
   Schema
-  (walker [this]
-          (clojure.core/fn [x]
-            (if (contains? vs x)
-              x
-              (macros/validation-error this x (list vs (utils/value-name x))))))
+  (spec [this] (leaf/leaf-spec (spec/precondition this #(contains? vs %) #(list vs %))))
   (explain [this] (cons 'enum vs)))
 
 (clojure.core/defn enum
@@ -311,22 +271,18 @@
 
 (clojure.core/defrecord Predicate [p? pred-name]
   Schema
-  (walker [this]
-          (clojure.core/fn [x]
-            (if-let [reason (macros/try-catchall (when-not (p? x) 'not) (catch e 'throws?))]
-              (macros/validation-error this x (list pred-name (utils/value-name x)) reason)
-              x)))
+  (spec [this] (leaf/leaf-spec (spec/precondition this p? #(list pred-name %))))
   (explain [this]
-           (cond (= p? integer?) 'Int
-                 (= p? keyword?) 'Keyword
-                 (= p? symbol?) 'Symbol
-                 (= p? string?) 'Str
-                 :else (list 'pred pred-name))))
+    (cond (= p? integer?) 'Int
+          (= p? keyword?) 'Keyword
+          (= p? symbol?) 'Symbol
+          (= p? string?) 'Str
+          :else (list 'pred pred-name))))
 
 (clojure.core/defn pred
   "A value for which p? returns true (and does not throw).
    Optional pred-name can be passed for nicer validation errors."
-  ([p?] (pred p? p?))
+  ([p?] (pred p? (symbol (utils/fn-name p?))))
   ([p? pred-name]
      (when-not (ifn? p?)
        (macros/error! (utils/format* "Not a function: %s" p?)))
@@ -342,11 +298,12 @@
 ;; and put it in metadata of the record so that equality is preserved, along with the name.
 (clojure.core/defrecord Protocol [p]
   Schema
-  (walker [this]
-          (clojure.core/fn [x]
-            (if ((:proto-pred (meta this)) x)
-              x
-              (macros/validation-error this x (list 'satisfies? (protocol-name this) (utils/value-name x))))))
+  (spec [this]
+    (leaf/leaf-spec
+     (spec/precondition
+      this
+      #((:proto-pred (meta this)) %)
+      #(list 'satisfies? (protocol-name this) %))))
   (explain [this] (list 'protocol (protocol-name this))))
 
 ;; The cljs version is macros/protocol by necessity, since cljs `satisfies?` is a macro.
@@ -357,8 +314,7 @@
    schema creation time, since that's impossible in cljs and breaks later
    extends in Clojure.
 
-   A macro for cljs sake, since `satisfies?` is a macro in cljs.
-"
+   A macro for cljs sake, since `satisfies?` is a macro in cljs."
   [p]
   `(with-meta (->Protocol ~p)
      {:proto-pred #(satisfies? ~p %)
@@ -370,17 +326,11 @@
 (extend-protocol Schema
   #+clj java.util.regex.Pattern
   #+cljs js/RegExp
-  (walker [this]
-    (clojure.core/fn [x]
-      (cond (not (string? x))
-            (macros/validation-error this x (list 'string? (utils/value-name x)))
-
-            (not (re-find this x))
-            (macros/validation-error this x (list 're-find
-                                                  (explain this)
-                                                  (utils/value-name x)))
-
-            :else x)))
+  (spec [this]
+    (leaf/leaf-spec
+     (some-fn
+      (spec/simple-precondition this string?)
+      (spec/precondition this #(re-find this %) #(list 're-find (explain this) %)))))
   (explain [this]
     #+clj (symbol (str "#\"" this "\""))
     #+cljs (symbol (str "#\"" (.slice (str this) 1 -1) "\""))))
@@ -403,25 +353,23 @@
 
 (def Int
   "Any integral number"
-  (pred integer? 'integer?))
+  (pred integer?))
 
 (def Keyword
   "A keyword"
-  (pred keyword? 'keyword?))
+  (pred keyword?))
 
 (def Symbol
   "A symbol"
-  (pred symbol? 'symbol?))
+  (pred symbol?))
 
 (def Regex
   "A regular expression"
   #+clj java.util.regex.Pattern
   #+cljs (reify Schema ;; Closure doesn't like if you just def as js/RegExp
-           (walker [this] (clojure.core/fn [x]
-                            (if (instance? js/RegExp x)
-                              x
-                              (macros/validation-error
-                               this x (list 'instance? 'js/RegExp (utils/value-name x))))))
+           (spec [this]
+             (leaf/leaf-spec
+              (spec/precondition this #(instance? js/RegExp %) #(list 'instance? 'js/RegExp %))))
            (explain [this] 'Regex)))
 
 (def Inst
@@ -435,17 +383,17 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Simple composite Schemas
+;;; Variant schemas (and other unit containers)
 
 ;;; maybe (nil)
 
 (clojure.core/defrecord Maybe [schema]
   Schema
-  (walker [this]
-          (let [sub-walker (subschema-walker schema)]
-            (clojure.core/fn [x]
-              (when-not (nil? x)
-                (sub-walker x)))))
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     [{:guard nil? :schema (eq nil)}
+      {:schema schema}]))
   (explain [this] (list 'maybe (explain schema))))
 
 (clojure.core/defn maybe
@@ -458,9 +406,10 @@
 
 (clojure.core/defrecord NamedSchema [schema name]
   Schema
-  (walker [this]
-          (let [sub-walker (subschema-walker schema)]
-            (clojure.core/fn [x] (utils/wrap-error-name name (sub-walker x)))))
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     [{:schema schema :wrap-error #(utils/->NamedError name %)}]))
   (explain [this] (list 'named (explain schema) name)))
 
 (clojure.core/defn named
@@ -473,47 +422,71 @@
 
 (clojure.core/defrecord Either [schemas]
   Schema
-  (walker [this]
-          (let [sub-walkers (mapv subschema-walker schemas)]
-            (clojure.core/fn [x]
-              (loop [sub-walkers (seq sub-walkers)]
-                (if-not sub-walkers
-                  (macros/validation-error
-                   this x
-                   (list 'some (list 'check '% (utils/value-name x)) 'schemas))
-                  (let [res ((first sub-walkers) x)]
-                    (if-not (utils/error? res)
-                      res
-                      (recur (next sub-walkers)))))))))
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     (for [s schemas]
+       {:guard (complement (checker s))
+        :schema s})
+     #(list 'matches-some-either-clause? %)))
   (explain [this] (cons 'either (map explain schemas))))
 
 (clojure.core/defn either
-  "A value that must satisfy at least one schema in schemas."
+  "A value that must satisfy at least one schema in schemas.
+   Note that `either` does not work properly with coercion
+
+   WARNING: either does not work with coercion.  It is also slow and gives
+   bad error messages.  Please consider using `conditional` and friends
+   instead; they are more efficient, provide better error messages,
+   and work with coercion."
   [& schemas]
   (Either. schemas))
+
+
+;;; constrained (matches precondition and schema)
+
+(clojure.core/defrecord Constrained [schema pred fn-name]
+  Schema
+  (spec [this]
+    (variant/variant-spec
+     (spec/precondition this pred #(list fn-name %))
+     [{:schema schema}]))
+  (explain [this] (list 'constrained (explain schema) fn-name)))
+
+(clojure.core/defn constrained
+  "A value that must satisfy both schema and precondition.
+   Replacement for `both` with cleaner semantics."
+  ([schema pred]
+     (constrained schema pred (symbol (utils/fn-name pred))))
+  ([schema pred pred-name]
+     (Constrained. schema pred pred-name)))
 
 
 ;;; both (satisfies this schema and that one)
 
 (clojure.core/defrecord Both [schemas]
   Schema
-  (walker [this]
-          (let [sub-walkers (mapv subschema-walker schemas)]
-            ;; Both doesn't really have a clean semantics for non-identity walks, but we can
-            ;; do something pretty reasonable and assume we walk in order passing the result
-            ;; of each walk to the next, and failing at the first error
-            (clojure.core/fn [x]
-              (reduce
-               (clojure.core/fn [x sub-walker]
-                 (if (utils/error? x)
-                   x
-                   (sub-walker x)))
-               x
-               sub-walkers))))
-  (explain [this] (cons 'both (map explain schemas))))
+  (spec [this] this)
+  (explain [this] (cons 'both (map explain schemas)))
 
-(clojure.core/defn both
-  "A value that must satisfy every schema in schemas."
+  spec/CoreSpec
+  (subschemas [this] schemas)
+  (checker [this params]
+    (reduce
+     (clojure.core/fn [f t]
+       (clojure.core/fn [x]
+         (let [tx (t x)]
+           (if (utils/error? tx)
+             tx
+             (f (or tx x))))))
+     (map #(spec/sub-checker {:schema %} params) (reverse schemas)))))
+
+(clojure.core/defn ^{:deprecated "1.0.0"} both
+  "A value that must satisfy every schema in schemas.
+
+   DEPRECATED: prefer 'constrained' instead.
+
+   When used with coercion, coerces each schema in sequence."
   [& schemas]
   (Both. schemas))
 
@@ -522,17 +495,16 @@
 
 (clojure.core/defrecord ConditionalSchema [preds-and-schemas]
   Schema
-  (walker [this]
-          (let [preds-and-walkers (mapv (clojure.core/fn [[pred schema]] [pred (subschema-walker schema)])
-                                        preds-and-schemas)]
-            (clojure.core/fn [x]
-              (if-let [[_ match] (first (filter (clojure.core/fn [[pred]] (pred x)) preds-and-walkers))]
-                (match x)
-                (macros/validation-error this x (list 'matches-some-condition? (utils/value-name x)))))))
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     (for [[p s] preds-and-schemas]
+       {:guard p :schema s})
+     #(list 'matches-some-condition? %))) ;; TODO: improve error message
   (explain [this]
-           (->> preds-and-schemas
-                (mapcat (clojure.core/fn [[pred schema]] [pred (explain schema)]))
-                (cons 'conditional))))
+    (->> preds-and-schemas
+         (mapcat (clojure.core/fn [[pred schema]] [pred (explain schema)]))
+         (cons 'conditional))))
 
 (clojure.core/defn conditional
   "Define a conditional schema.  Takes args like cond,
@@ -563,22 +535,17 @@
 
 (clojure.core/defrecord Recursive [derefable]
   Schema
-  (walker [this]
-          (let [a (atom nil)]
-            (reset! a (start-walker
-                       (let [old subschema-walker]
-                         (clojure.core/fn [s] (if (= s this) #(@a %) (old s))))
-                       @derefable))))
+  (spec [this] (variant/variant-spec spec/+no-precondition+ [{:schema @derefable}]))
   (explain [this]
-           (list 'recursive
-                 (if #+clj (var? derefable) #+cljs (instance? Var derefable)
-                     (list 'var (var-name derefable))
-                     #+clj
-                     (format "%s@%x"
-                             (.getName (class derefable))
-                             (System/identityHashCode derefable))
-                     #+cljs
-                     '...))))
+    (list 'recursive
+          (if #+clj (var? derefable) #+cljs (instance? Var derefable)
+              (list 'var (var-name derefable))
+              #+clj
+              (format "%s@%x"
+                      (.getName (class derefable))
+                      (System/identityHashCode derefable))
+              #+cljs
+              '...))))
 
 (clojure.core/defn recursive
   "Support for (mutually) recursive schemas by passing a var that points to a schema,
@@ -587,6 +554,7 @@
   (when-not #+clj (instance? clojure.lang.IDeref schema) #+cljs (satisfies? IDeref schema)
             (macros/error! (utils/format* "Not an IDeref: %s" schema)))
   (Recursive. schema))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Map Schemas
@@ -610,10 +578,6 @@
 
 
 ;;; Definitions for required and optional keys, and single entry validators
-
-(def ^:no-doc +missing+
-  "A sentinel value representing missing portions of the input data."
-  ::missing)
 
 (clojure.core/defrecord RequiredKey [k])
 
@@ -649,6 +613,35 @@
   (or (required-key? ks)
       (optional-key? ks)))
 
+;; A schema for a single map entry.
+(clojure.core/defrecord MapEntry [key-schema val-schema]
+  Schema
+  (spec [this]
+    (collection/collection-spec
+     spec/+no-precondition+
+     vec
+     [(collection/one-element true key-schema (clojure.core/fn [item-fn e] (item-fn (key e)) e))
+      (collection/one-element true val-schema (clojure.core/fn [item-fn e] (item-fn (val e)) nil))]
+     (clojure.core/fn [[k] [xk xv] _]
+       (if-let [k-err (utils/error-val xk)]
+         [k-err 'invalid-key]
+         [k (utils/error-val xv)]))))
+  (explain [this]
+    (list
+     'map-entry
+     (explain key-schema)
+     (explain val-schema))))
+
+(clojure.core/defn map-entry [key-schema val-schema]
+  (MapEntry. key-schema val-schema))
+
+(clojure.core/defn find-extra-keys-schema [map-schema]
+  (let [key-schemata (remove specific-key? (keys map-schema))]
+    (macros/assert! (< (count key-schemata) 2)
+                    "More than one non-optional/required key schemata: %s"
+                    (vec key-schemata))
+    (first key-schemata)))
+
 (clojure.core/defn- explain-kspec [kspec]
   (if (specific-key? kspec)
     (if (keyword? kspec)
@@ -658,112 +651,49 @@
             (explicit-schema-key kspec)))
     (explain kspec)))
 
-;; A schema for a single map entry.  kspec is either a keyword, required or optional key,
-;; or key schema.  val-schema is a value schema.
-(clojure.core/defrecord MapEntry [kspec val-schema]
-  Schema
-  (walker [this]
-          (let [val-walker (subschema-walker val-schema)]
-            (if (specific-key? kspec)
-              (let [optional? (optional-key? kspec)
-                    k (explicit-schema-key kspec)]
-                (clojure.core/fn [x]
-                  (cond (identical? +missing+ x)
-                        (when-not optional?
-                          (utils/error [k 'missing-required-key]))
-
-                        (not (= 2 (count x)))
-                        (macros/validation-error this x (list = 2 (list 'count (utils/value-name x))))
-
-                        :else
-                        (let [[xk xv] x]
-                          (assert (= xk k))
-                          (let [vres (val-walker xv)]
-                            (if-let [ve (utils/error-val vres)]
-                              (utils/error [xk ve])
-                              [xk vres]))))))
-              (let [key-walker (subschema-walker kspec)]
-                (clojure.core/fn [x]
-                  (if-not (= 2 (count x))
-                    (macros/validation-error this x (list = 2 (list 'count (utils/value-name x))))
-                    (let [out-k (key-walker (key x))
-                          out-ke (utils/error-val out-k)
-                          out-v (val-walker (val x))
-                          out-ve (utils/error-val out-v)]
-                      (if (or out-ke out-ve)
-                        (utils/error [(or out-ke (key x)) (or out-ve 'invalid-key)])
-                        [out-k out-v]))))))))
-  (explain [this]
-           (list
-            'map-entry
-            (explain-kspec kspec)
-            (explain val-schema))))
-
-(clojure.core/defn map-entry [kspec val-schema]
-  (MapEntry. kspec val-schema))
-
-
-;;; Implementation helper functions
-
-(clojure.core/defn find-extra-keys-schema [map-schema]
-  (let [key-schemata (remove specific-key? (keys map-schema))]
-    (macros/assert! (< (count key-schemata) 2)
-                    "More than one non-optional/required key schemata: %s"
-                    (vec key-schemata))
-    (first key-schemata)))
-
-(clojure.core/defn- preserve-map-type [original walker-result]
-  (if (and (utils/record? original) (not (utils/error? walker-result)))
-    (into original walker-result)
-    walker-result))
-
-(clojure.core/defn- map-walker [map-schema]
-  (let [extra-keys-schema (find-extra-keys-schema map-schema)
-        extra-walker (when extra-keys-schema
-                       (subschema-walker (apply map-entry (find map-schema extra-keys-schema))))
-        explicit-schema (dissoc map-schema extra-keys-schema)
-        explicit-walkers (into {} (for [[k v] explicit-schema]
-                                    [(explicit-schema-key k)
-                                     (subschema-walker (map-entry k v))]))
-        err-conj (utils/result-builder (constantly {}))]
-    (when-not (= (count explicit-schema) (count explicit-walkers))
-      (macros/error! (utils/format* "Schema has multiple variants of the same explicit key: %s"
-                                    (->> (keys explicit-schema)
-                                         (group-by explicit-schema-key)
-                                         vals
-                                         (filter #(> (count %) 1))
-                                         (apply concat)
-                                         (mapv explain-kspec)))))
-    (clojure.core/fn [x]
-      (if-not (map? x)
-        (macros/validation-error map-schema x (list 'map? (utils/value-name x)))
-        (preserve-map-type
-         x
-         (loop [ok-key #{} explicit-walkers (seq explicit-walkers) out {}]
-           (if-not explicit-walkers
-             (reduce
-              (if extra-walker
-                (clojure.core/fn [out e]
-                  (err-conj out (extra-walker e)))
-                (clojure.core/fn [out [k _]]
-                  (err-conj out (utils/error [k 'disallowed-key]))))
-              out
-              (remove (clojure.core/fn [[k v]] (ok-key k)) x))
-             (let [[wk wv] (first explicit-walkers)]
-               (recur (conj ok-key wk)
-                      (next explicit-walkers)
-                      (err-conj out (wv (or (find x wk) +missing+))))))))))))
+(clojure.core/defn- map-spec [this]
+  (collection/collection-spec
+   (spec/simple-precondition this map?)
+   #(into {} %)
+   (let [extra-keys-schema (find-extra-keys-schema this)]
+     (let [duplicate-keys (->> (dissoc this extra-keys-schema)
+                               keys
+                               (group-by explicit-schema-key)
+                               vals
+                               (filter #(> (count %) 1))
+                               (apply concat)
+                               (mapv explain-kspec))]
+       (macros/assert! (empty? duplicate-keys)
+                       "Schema has multiple variants of the same explicit key: %s" duplicate-keys))
+     (concat
+      (for [[k v] (dissoc this extra-keys-schema)]
+        (let [rk (explicit-schema-key k)
+              required? (required-key? k)]
+          (collection/one-element
+           required? (map-entry (eq rk) v)
+           (clojure.core/fn [item-fn m]
+             (let [e (find m rk)]
+               (cond e (item-fn e)
+                     required? (item-fn (utils/error [rk 'missing-required-key])))
+               (if e
+                 (dissoc #+clj (if (instance? clojure.lang.PersistentStructMap m) (into {} m) m) #+cljs m
+                         rk)
+                 m))))))
+      (when extra-keys-schema
+        [(collection/all-elements (apply map-entry (find this extra-keys-schema)))])))
+   (clojure.core/fn [_ elts extra]
+     (into {} (concat (keep utils/error-val elts) (for [[k _] extra] [k 'disallowed-key]))))))
 
 (clojure.core/defn- map-explain [this]
-  (into {} (for [[k v] this] (vec (next (explain (map-entry k v)))))))
+  (into {} (for [[k v] this] [(explain-kspec k) (explain v)])))
 
 (extend-protocol Schema
   #+clj clojure.lang.APersistentMap
   #+cljs cljs.core.PersistentArrayMap
-  (walker [this] (map-walker this))
+  (spec [this] (map-spec this))
   (explain [this] (map-explain this))
   #+cljs cljs.core.PersistentHashMap
-  #+cljs (walker [this] (map-walker this))
+  #+cljs (spec [this] (map-spec this))
   #+cljs (explain [this] (map-explain this)))
 
 
@@ -775,16 +705,13 @@
 (extend-protocol Schema
   #+clj clojure.lang.APersistentSet
   #+cljs cljs.core.PersistentHashSet
-  (walker [this]
+  (spec [this]
     (macros/assert! (= (count this) 1) "Set schema must have exactly one element")
-    (let [sub-walker (subschema-walker (first this))]
-      (clojure.core/fn [x]
-        (or (when-not (set? x)
-              (macros/validation-error this x (list 'set? (utils/value-name x))))
-            (let [[good bad] ((juxt remove keep) utils/error-val (map sub-walker x))]
-              (if (seq bad)
-                (utils/error (set bad))
-                (set good)))))))
+    (collection/collection-spec
+     (spec/simple-precondition this set?)
+     set
+     [(collection/all-elements (first this))]
+     (clojure.core/fn [_ xs _] (set (keep utils/error-val xs)))))
   (explain [this] (set [(explain (first this))])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -807,16 +734,13 @@
    col))
 
 (clojure.core/defrecord Queue [schema]
- Schema
- (walker [this]
-    (let [sub-walker (subschema-walker schema)]
-      (clojure.core/fn [x]
-        (or (when-not (queue? x)
-              (macros/validation-error this x (list 'queue? (utils/value-name x))))
-            (let [[good bad] ((juxt remove keep) utils/error-val (map sub-walker x))]
-              (if (seq bad)
-                (utils/error (as-queue bad))
-                (as-queue good)))))))
+  Schema
+  (spec [this]
+    (collection/collection-spec
+     (spec/simple-precondition this queue?)
+     as-queue
+     [(collection/all-elements schema)]
+     (clojure.core/fn [_ xs _] (as-queue (keep utils/error-val xs)))))
   (explain [this] (list 'queue (explain schema))))
 
 (clojure.core/defn queue
@@ -861,41 +785,36 @@
 (extend-protocol Schema
   #+clj clojure.lang.APersistentVector
   #+cljs cljs.core.PersistentVector
-  (walker [this]
-    (let [[singles multi] (parse-sequence-schema this)
-          single-walkers (vec (for [^One s singles]
-                                [s (subschema-walker (.-schema s))]))
-          multi-walker (when multi (subschema-walker multi))
-          err-conj (utils/result-builder (clojure.core/fn [m] (vec (repeat (count m) nil))))]
-      (clojure.core/fn [x]
-        (or (when-not (or (nil? x) (sequential? x) #+clj (instance? java.util.List x))
-              (macros/validation-error this x (list 'sequential? (utils/value-name x))))
-            (loop [single-walkers single-walkers x x out []]
-              (if-let [[^One first-single single-walker] (first single-walkers)]
-                (if (empty? x)
-                  (if (.-optional? first-single)
-                    out
-                    (err-conj out
-                              (macros/validation-error
-                               (vec (map first single-walkers))
-                               nil
-                               (list* 'present?
-                                      (for [[^One single] single-walkers
-                                            :while (not (.-optional? single))]
-                                        (.-name single))))))
-                  (recur (next single-walkers)
-                         (rest x)
-                         (err-conj out
-                                   (utils/wrap-error-name
-                                    (.-name first-single)
-                                    (single-walker (first x))))))
-                (cond multi
-                      (reduce err-conj out (map multi-walker x))
-
-                      (seq x)
-                      (err-conj out (macros/validation-error nil x (list 'has-extra-elts? (count x))))
-                      :else
-                      out)))))))
+  (spec [this]
+    (collection/collection-spec
+     (spec/precondition
+      this
+      (clojure.core/fn [x] (or (nil? x) (sequential? x) #+clj (instance? java.util.List x)))
+      #(list 'sequential? %))
+     vec
+     (let [[singles multi] (parse-sequence-schema this)]
+       (concat
+        (for [^One s singles]
+          (let [required? (not (.-optional? s))]
+            (collection/one-element
+             required? (named (.-schema s) (.-name s))
+             (clojure.core/fn [item-fn x]
+               (if-let [x (seq x)]
+                 (do (item-fn (first x))
+                     (rest x))
+                 (do (when required?
+                       (item-fn
+                        (macros/validation-error
+                         (.-schema s) ::missing
+                         (list 'present? (.-name s)))))
+                     nil))))))
+        (when multi
+          [(collection/all-elements multi)])))
+     (clojure.core/fn [_ elts extra]
+       (let [head (mapv utils/error-val elts)]
+         (if (seq extra)
+           (conj head (utils/error-val (macros/validation-error nil extra (list 'has-extra-elts? (count extra)))))
+           head)))))
   (explain [this]
     (let [[singles multi] (parse-sequence-schema this)]
       (vec
@@ -916,34 +835,40 @@
 ;;; Record Schemas
 
 ;; A Record schema describes a value that must have the correct type, and its body must
-;; also satisfy a map schema.  An optional :extra-validator-fn can also be passed to do
+;; also satisfy a map schema.  An optional :extra-validator-fn can also be attached to do
 ;; additional validation.
 
 (clojure.core/defrecord Record [klass schema]
   Schema
-  (walker [this]
-          (let [map-checker (subschema-walker schema)
-                pred-checker (when-let [evf (:extra-validator-fn this)]
-                               (subschema-walker (pred evf)))]
-            (clojure.core/fn [r]
-              (or (when-not (instance? klass r)
-                    (macros/validation-error this r (list 'instance? klass (utils/value-name r))))
-                  (let [res (map-checker r)]
-                    (if (utils/error? res)
-                      res
-                      (let [pred-res (when pred-checker (pred-checker r))]
-                        (if (utils/error? pred-res)
-                          pred-res
-                          res))))))))
+  (spec [this]
+    (assoc (spec schema)
+      :pre (let [p (spec/precondition this #(instance? klass %) #(list 'instance? klass %))]
+             (if-let [evf (:extra-validator-fn this)]
+               (some-fn p (spec/precondition this evf #(list 'passes-extra-validation? %)))
+               p))
+      :constructor (:constructor (meta this))))
   (explain [this]
-           (list 'record #+clj (symbol (.getName ^Class klass)) #+cljs (symbol (pr-str klass)) (explain schema))))
+    (list 'record #+clj (symbol (.getName ^Class klass)) #+cljs (symbol (pr-str klass)) (explain schema))))
 
-(clojure.core/defn record
-  "A Record instance of type klass, whose elements match map schema 'schema'."
-  [klass schema]
+(clojure.core/defn record* [klass schema map-constructor]
   #+clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
-  (Record. klass schema))
+  (with-meta (Record. klass schema) {:constructor map-constructor}))
+
+(defmacro record
+  "A Record instance of type klass, whose elements match map schema 'schema'.
+
+   The final argument is the map constructor of the record type; if you do
+   not pass one, an attempt is made to find the corresponding function
+   (but this may fail in exotic circumstances)."
+  ([klass schema]
+     `(record ~klass ~schema
+              (macros/if-cljs
+               ~(let [bits (str/split (name klass) #"/")]
+                  (symbol (str/join "/" (concat (butlast bits) [(str "map->" (last bits))]))))
+               #(~(symbol (str (name klass) "/create")) %))))
+  ([klass schema map-constructor]
+     `(record* ~klass ~schema #(~map-constructor (into {} %)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -963,15 +888,11 @@
 
 (clojure.core/defrecord FnSchema [output-schema input-schemas] ;; input-schemas sorted by arity
   Schema
-  (walker [this]
-          (clojure.core/fn [x]
-            (if (ifn? x)
-              x
-              (macros/validation-error this x (list 'ifn? (utils/value-name x))))))
+  (spec [this] (leaf/leaf-spec (spec/simple-precondition this ifn?)))
   (explain [this]
-           (if (> (count input-schemas) 1)
-             (list* '=>* (explain output-schema) (map explain-input-schema input-schemas))
-             (list* '=> (explain output-schema) (explain-input-schema (first input-schemas))))))
+    (if (> (count input-schemas) 1)
+      (list* '=>* (explain output-schema) (map explain-input-schema input-schemas))
+      (list* '=> (explain output-schema) (explain-input-schema (first input-schemas))))))
 
 (clojure.core/defn- arity [input-schema]
   (if (seq input-schema)
@@ -1035,8 +956,8 @@
   ([name docstring form]
      `(def ~name ~docstring
         (vary-meta
-          (schema-with-name ~form '~name)
-          assoc :ns '~(ns-name *ns*)))))
+         (schema-with-name ~form '~name)
+         assoc :ns '~(ns-name *ns*)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -484,8 +484,8 @@
        {:guard p :schema s})
      #(list (or error-symbol
                 (if (= 1 (count preds-and-schemas))
-                  (symbol (utils/fn-name (ffirst preds-and-schemas))))
-                'some-matching-condition?)
+                  (symbol (utils/fn-name (ffirst preds-and-schemas)))
+                  'some-matching-condition?))
             %)))
   (explain [this]
     (cons 'conditional

--- a/src/cljx/schema/experimental/abstract_map.cljx
+++ b/src/cljx/schema/experimental/abstract_map.cljx
@@ -1,0 +1,74 @@
+(ns schema.experimental.abstract-map
+  "Schemas representing abstract classes and subclasses"
+  (:require
+   [clojure.string :as str]
+   [schema.core :as s :include-macros true]
+   [schema.spec.core :as spec]
+   [schema.spec.variant :as variant]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private: helpers
+
+(defprotocol PExtensibleSchema
+  (extend-schema! [this extension schema-name dispatch-values]))
+
+;; a "subclass"
+(defrecord SchemaExtension [schema-name base-schema extended-schema explain-value]
+  s/Schema
+  (spec [this]
+    (variant/variant-spec spec/+no-precondition+ [{:schema extended-schema}]))
+  (explain [this]
+    (list 'extend-schema
+          schema-name
+          (s/schema-name base-schema)
+          (s/explain explain-value))))
+
+;; an "abstract class"
+(defrecord AbstractSchema [sub-schemas dispatch-key schema open?]
+  s/Schema
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     (concat
+      (for [[k s] @sub-schemas]
+        {:guard #(= (keyword (dispatch-key %)) k)
+         :schema s})
+      (when open?
+        [{:schema (assoc schema dispatch-key s/Keyword s/Any s/Any)}]))
+     (fn [v] (list (set (keys @sub-schemas)) (list dispatch-key v)))))
+  (explain [this]
+    (list 'abstract-map-schema dispatch-key (s/explain schema) (set (keys @sub-schemas))))
+
+  PExtensibleSchema
+  (extend-schema! [this extension schema-name dispatch-values]
+    (let [sub-schema (assoc (merge schema extension)
+                       dispatch-key (apply s/enum dispatch-values))
+          ext-schema (s/schema-with-name
+                      (SchemaExtension. schema-name this sub-schema extension)
+                      (name schema-name))]
+      (swap! sub-schemas merge (into {} (for [k dispatch-values] [k ext-schema])))
+      ext-schema)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(s/defn abstract-map-schema
+  "A schema representing an 'abstract class' map that must match at least one concrete
+   subtype (indicated by the value of dispatch-key, a keyword).  Add subtypes by calling
+   `extend-schema`."
+  [dispatch-key :- s/Keyword schema :- (s/pred map?)]
+  (AbstractSchema. (atom {}) dispatch-key schema false))
+
+(s/defn open-abstract-map-schema
+  "Like abstract-map-schema, but allows unknown types to validate (for, e.g. forward
+   compatibility)."
+  [dispatch-key :- s/Keyword schema :- (s/pred map?)]
+  (AbstractSchema. (atom {}) dispatch-key schema true))
+
+(defmacro extend-schema
+  [schema-name extensible-schema dispatch-values extension]
+  `(def ~schema-name
+     (extend-schema! ~extensible-schema ~extension '~schema-name ~dispatch-values)))
+
+(defn sub-schemas [abstract-schema]
+  @(.-sub-schemas ^AbstractSchema abstract-schema))

--- a/src/cljx/schema/spec/collection.cljx
+++ b/src/cljx/schema/spec/collection.cljx
@@ -1,0 +1,85 @@
+(ns schema.spec.collection
+  "A collection spec represents a collection of elements,
+   each of which is itself schematized."
+  (:require
+   [schema.utils :as utils]
+   [schema.spec.core :as spec]))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Collection Specs
+
+(defn- element-transformer [e params then]
+  (let [parser (:parser e)
+        c (spec/sub-checker e params)]
+    #+clj (fn [^java.util.List res x]
+            (then res (parser (fn [t] (.add res (if (utils/error? t) t (c t)))) x)))
+    #+cljs (fn [res x]
+             (then res (parser (fn [t] (swap! res conj (if (utils/error? t) t (c t)))) x)))))
+
+#+clj ;; for performance
+(defn- has-error? [^java.util.List l]
+  (let [it (.iterator l)]
+    (loop []
+      (if (.hasNext it)
+        (if (utils/error? (.next it))
+          true
+          (recur))
+        false))))
+
+#+cljs
+(defn- has-error? [l]
+  (some utils/error? l))
+
+(defrecord CollectionSpec [pre constructor elements on-error]
+  spec/CoreSpec
+  (subschemas [this] (map :schema elements))
+  (checker [this params]
+    (let [constructor (if (:return-walked? params) constructor (fn [_] nil))
+          t (reduce
+             (fn [f e]
+               (element-transformer e params f))
+             (fn [_ x] x)
+             (reverse elements))]
+      (fn [x]
+        (or (pre x)
+            (let [res #+clj (java.util.ArrayList.) #+cljs (atom [])
+                  remaining (t res x)
+                  res #+clj res #+cljs @res]
+              (if (or (seq remaining) (has-error? res))
+                (utils/error (on-error x res remaining))
+                (constructor res))))))))
+
+(defn collection-spec
+  "A collection represents a collection of elements, each of which is itself
+   schematized.  At the top level, the collection has a precondition
+   (presumably on the overall type), a constructor for the collection from a
+   sequence of items, an element spec, and a function that constructs a
+   descriptive error on failure.
+
+   The element spec is a sequence of maps, each of which provides an element
+   schema, cardinality, parser (allowing for efficient processing of
+   structured collections), and optional error wrapper."
+  [pre ;- spec/Precondition
+   constructor ;- (s/=> s/Any [(s/named s/Any 'checked-value)])
+   elements ;- [{:schema (s/protocol Schema)
+   ;;            :cardinality (s/enum :exactly-one :at-most-one :zero-or-more)
+   ;;            :parser (s/=> s/Any (s/=> s/Any s/Any) s/Any) ; takes [item-fn coll], calls item-fn on matching items, returns remaining.
+   ;;            (s/optional-key :error-wrap) (s/pred fn?)}]
+   on-error ;- (=> s/Any (s/named s/Any 'value) [(s/named s/Any 'checked-element)] [(s/named s/Any 'unmatched-element)])
+   ]
+  (->CollectionSpec pre constructor elements on-error))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Helpers for creating 'elements'
+
+(defn all-elements [schema]
+  {:schema schema
+   :cardinality :zero-or-more
+   :parser (fn [item-fn coll] (doseq [x coll] (item-fn x)) nil)})
+
+(defn one-element [required? schema parser]
+  {:schema schema
+   :cardinality (if required? :exactly-one :at-most-one)
+   :parser parser})

--- a/src/cljx/schema/spec/core.cljx
+++ b/src/cljx/schema/spec/core.cljx
@@ -27,7 +27,7 @@
       - returned-walked? - a boolean specifying whether to return a walked version of the data
         (otherwise, nil is returned which increases performance)
       - cache - a map structure from schema to checker, which speeds up checker creation
-        when the same subschema appears multiple times, and also faciliates handling
+        when the same subschema appears multiple times, and also facilitates handling
         recursive schemas."))
 
 

--- a/src/cljx/schema/spec/core.cljx
+++ b/src/cljx/schema/spec/core.cljx
@@ -1,0 +1,87 @@
+(ns schema.spec.core
+  "Protocol and preliminaries for Schema 'specs', which are a common language
+   for schemas to use to express their structure."
+  (:require
+   #+clj [schema.macros :as macros]
+   [schema.utils :as utils])
+  #+cljs (:require-macros [schema.macros :as macros]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Core spec protocol
+
+(defprotocol CoreSpec
+  "Specs are a common language for Schemas to express their structure.
+   These two use-cases aren't priveledged, just the two that are considered core
+   to being a Spec."
+  (subschemas [this]
+    "List all subschemas")
+  (checker [this params]
+    "Create a function that takes [data], and either returns a walked version of data
+     (by default, usually just data), or a utils/ErrorContainer containing value that looks
+     like the 'bad' parts of data with ValidationErrors at the leaves describing the failures.
+
+     params are: subschema-walker, return-walked?, and cache."))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Preconditions
+
+;; A Precondition is a function of a value that returns a ValidationError if the value
+;; does not satisfy the precondition, and otherwise returns nil.
+;; e.g., (s/defschema Precondition (s/=> (s/maybe schema.utils.ValidationError) s/Any))
+;; as such, a precondition is essentially a very simple checker.
+
+(def +no-precondition+ (fn [_] nil))
+
+(defn precondition
+  "Helper for making preconditions.
+   Takes a schema, predicate p, and error function err-f.
+   If the datum passes the predicate, returns nil.
+   Otherwise, returns a validation error with description (err-f datum-description),
+   where datum-description is a (short) printable standin for the datum."
+  [s p err-f]
+  (fn [x]
+    (when-let [reason (macros/try-catchall (when-not (p x) 'not) (catch e# 'throws?))]
+      (macros/validation-error s x (err-f (utils/value-name x)) reason))))
+
+(defmacro simple-precondition
+  "A simple precondition where f-sym names a predicate (e.g. (simple-precondition s map?)"
+  [s f-sym]
+  `(precondition ~s ~f-sym #(list (quote ~f-sym) %)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Helpers
+
+(defn run-checker
+  [f return-walked? s]
+  (f
+   s
+   {:subschema-checker f
+    :return-walked? return-walked?
+    :cache #+clj (java.util.IdentityHashMap.) #+cljs (atom {})}))
+
+(defn with-cache [^java.util.Map cache cache-key wrap-recursive-delay result-fn]
+  (if-let [w #+clj (.get cache cache-key) #+cljs (@cache cache-key)]
+    (if (= ::in-progress w) ;; recursive
+      (wrap-recursive-delay (delay #+clj (.get cache cache-key) #+cljs (@cache cache-key)))
+      w)
+    (do #+clj (.put cache cache-key ::in-progress) #+cljs (swap! cache assoc cache-key ::in-progress)
+        (let [res (result-fn)]
+          #+clj (.put cache cache-key res) #+cljs (swap! cache assoc cache-key res)
+          res))))
+
+(defn sub-checker
+  [{:keys [schema error-wrap]}
+   {:keys [subschema-checker ^java.util.Map cache] :as params}]
+  (with-cache cache schema
+    (fn [d] (fn [x] (@d x)))
+    (fn []
+      (let [sub (subschema-checker schema params)]
+        (if error-wrap
+          (fn [x]
+            (let [res (sub x)]
+              (if-let [e (utils/error-val res)]
+                (utils/error (error-wrap res))
+                res)))
+          sub)))))

--- a/src/cljx/schema/spec/leaf.cljx
+++ b/src/cljx/schema/spec/leaf.cljx
@@ -1,0 +1,20 @@
+(ns schema.spec.leaf
+  (:require
+   [schema.spec.core :as spec]))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Leaf Specs
+
+(defrecord LeafSpec [pre]
+  spec/CoreSpec
+  (subschemas [this] nil)
+  (checker [this params]
+    (fn [x] (or (pre x) x))))
+
+(defn leaf-spec
+  "A leaf spec represents an atomic datum that is checked completely
+   with a single precondition, and is otherwise a black box to Schema."
+  [pre ;- spec/Precondition
+   ]
+  (->LeafSpec pre))

--- a/src/cljx/schema/spec/variant.cljx
+++ b/src/cljx/schema/spec/variant.cljx
@@ -1,0 +1,57 @@
+(ns schema.spec.variant
+  (:require
+   #+clj [schema.macros :as macros]
+   [schema.utils :as utils]
+   [schema.spec.core :as spec])
+  #+cljs (:require-macros [schema.macros :as macros]))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Variant Specs
+
+(defn- option-step [o params else]
+  (let [g (:guard o)
+        c (spec/sub-checker o params)
+        step (if g
+               (fn [x] (if (g x) (c x) (else x)))
+               c)]
+    (if-let [wrap-error (:wrap-error o)]
+      (fn [x]
+        (let [res (step x)]
+          (if-let [e (utils/error-val res)]
+            (utils/error (wrap-error e))
+            res)))
+      step)))
+
+(defrecord VariantSpec [pre options err-f]
+  spec/CoreSpec
+  (subschemas [this] (map :schema options))
+  (checker [this params]
+    (let [t (reduce
+             (fn [f o]
+               (option-step o params f))
+             (fn [x] (macros/validation-error this x (err-f (utils/value-name x))))
+             (reverse options))]
+      (fn [x]
+        (or (pre x)
+            (t x))))))
+
+(defn variant-spec
+  "A variant spec represents a choice between a set of alternative
+   subschemas, e.g., a tagged union. It has an overall precondition,
+   set of options, and error function.
+
+   The semantics of `options` is that the options are processed in order;
+   the datum must match the schema for the first option for which `guard`
+   passes."
+  ([pre options]
+     (variant-spec pre options nil))
+  ([pre ;- spec/Precondition
+    options ;- [{:schema (s/protocol Schema)
+    ;;           (s/optional-key :guard) (s/pred fn?)
+    ;;           (s/optional-key :error-wrap) (s/pred fn?)}]
+    err-f ;- (s/pred fn?)
+    ]
+     (macros/assert! (or err-f (nil? (:guard (last options))))
+                     "when last option has a guard, err-f must be provided")
+     (->VariantSpec pre options err-f)))

--- a/src/cljx/schema/spec/variant.cljx
+++ b/src/cljx/schema/spec/variant.cljx
@@ -43,7 +43,11 @@
 
    The semantics of `options` is that the options are processed in order;
    the datum must match the schema for the first option for which `guard`
-   passes."
+   passes.
+
+   err-f is a function to produce an error message if none
+   of the guards match (and must be passed unless the last option has no
+   guard)."
   ([pre options]
      (variant-spec pre options nil))
   ([pre ;- spec/Precondition

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -67,7 +67,7 @@
                    (if (>= slash 0)
                      (str (subs s 0 slash) "/" (subs s (inc slash)))
                      s))]
-          (if (.startsWith raw "clojure.core/") (subs raw 13) raw)))
+          (string/replace raw #"^clojure.core/" "")))
 
 (defn record? [x]
   #+clj (instance? clojure.lang.IRecord x)

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -1,7 +1,12 @@
 (ns schema.utils
   "Private utilities used in schema implementation."
   (:refer-clojure :exclude [record?])
-  #+cljs (:require goog.string.format [goog.string :as gstring]))
+  #+clj (:require [clojure.string :as string])
+  #+cljs (:require
+          goog.string.format
+          [goog.string :as gstring]
+          [clojure.string :as string])
+  #+cljs (:require-macros [schema.utils :refer [char-map]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Miscellaneous helpers
@@ -40,18 +45,29 @@
       value
       (symbol (str "a-" #+clj (.getName ^Class t) #+cljs t)))))
 
-(defn memoize-id
-  "Identity version of memoize, because many schemas are records, and records
-   don't cache their hash codes (at least in Clojure 1.5.1).
-   Not thread safe, and doesn't cache falsey values."
+(defmacro char-map []
+  clojure.lang.Compiler/CHAR_MAP)
+
+(defn unmunge
+  "TODO: eventually use built in demunge in latest cljs."
+  [s]
+  (->> (char-map)
+       (sort-by #(- (count (second %))))
+       (reduce (fn [^String s [to from]] (string/replace s from (str to))) s)))
+
+(defn fn-name
+  "A meaningful name for a function that looks like its symbol, if applicable."
   [f]
-  #+clj (let [m (java.util.IdentityHashMap.)]
-          (fn [x]
-            (or (.get m x)
-                (let [res (f x)]
-                  (.put m x res)
-                  res))))
-  #+cljs (memoize f))
+  #+cljs (unmunge
+          (or (not-empty (second (re-find #"function ([^\(]*)\(" (str f))))
+              "function"))
+  #+clj (let [s (.getName (class f))
+              slash (.lastIndexOf s "$")
+              raw (unmunge
+                   (if (>= slash 0)
+                     (str (subs s 0 slash) "/" (subs s (inc slash)))
+                     s))]
+          (if (.startsWith raw "clojure.core/") (subs raw 13) raw)))
 
 (defn record? [x]
   #+clj (instance? clojure.lang.IRecord x)
@@ -116,24 +132,6 @@
 (defn error-val [x]
   (when (error? x)
     (.-error ^ErrorContainer x)))
-
-(defn wrap-error-name
-  "If maybe-error is an error, wrap the inner value in a NamedError; otherwise, return as-is"
-  [name maybe-error]
-  (if-let [e (error-val maybe-error)]
-    (error (NamedError. name e))
-    maybe-error))
-
-(defn result-builder
-  "Build up a result by conjing values, producing an error if at least one
-   sub-value returns an error."
-  [lift-to-error]
-  (fn conjer [m e]
-    (if-let [err (error-val e)]
-      (error (conj (or (error-val m) (lift-to-error m)) err))
-      (if-let [merr (error-val m)]
-        (error (conj merr nil))
-        (conj m e)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/clj/schema/test_macros.clj
+++ b/test/clj/schema/test_macros.clj
@@ -3,12 +3,13 @@
   (:require
    clojure.test
    [schema.core :as s]
-   [schema.macros :as sm]))
+   [schema.macros :as sm]
+   [schema.spec.core :as spec]))
 
 (defmacro valid!
   "Assert that x satisfies schema s, and the walked value is equal to the original."
   [s x]
-  `(let [x# ~x] (~'is (= x# ((s/start-walker s/walker ~s) x#)))))
+  `(let [x# ~x] (~'is (= x# ((spec/run-checker #(spec/checker (s/spec %1) %2) true ~s) x#)))))
 
 (defmacro invalid!
   "Assert that x does not satisfy schema s, optionally checking the stringified return value"

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -274,7 +274,7 @@
     (invalid! schema {:type :foo :baz "10"})
     (invalid! schema {:type :bar :baz 10} "{:baz (not (instance? java.lang.String 10))}")
     (invalid! schema {:type :zzz :baz 10}
-              "(not (matches-some-condition? a-clojure.lang.PersistentArrayMap))")
+              "(not (some-matching-condition? a-clojure.lang.PersistentArrayMap))")
     (is (s/explain schema))))
 
 (deftest if-test

--- a/test/cljx/schema/experimental/abstract_map_test.cljx
+++ b/test/cljx/schema/experimental/abstract_map_test.cljx
@@ -1,0 +1,48 @@
+(ns schema.experimental.abstract-map-test
+  #+clj (:use clojure.test [schema.test-macros :only [valid! invalid! invalid-call!]])
+  #+cljs (:use-macros
+          [cemerick.cljs.test :only [is deftest testing]]
+          [schema.test-macros :only [valid! invalid! invalid-call!]])
+  (:require
+   [schema.core :as s]
+   [schema.coerce :as coerce]
+   [schema.experimental.abstract-map :as abstract-map :include-macros true]
+   #+cljs cemerick.cljs.test))
+
+(s/defschema Animal
+  (abstract-map/abstract-map-schema
+   :type
+   {:age s/Num
+    :vegan? s/Bool}))
+
+(abstract-map/extend-schema Cat Animal [:cat] {:fav-catnip s/Str})
+
+(deftest extend-schema-test
+  (valid! Cat {:age 3 :vegan? false :fav-catnip "cosmic" :type :cat})
+  (invalid! Cat {:age 3 :vegan? false :fav-catnip "cosmic" :type :cat :foobar false})
+
+  (valid! Animal {:age 3 :vegan? false :fav-catnip "cosmic" :type :cat})
+  (invalid! Animal {:age 3 :vegan? false :type :cat}
+            "{:fav-catnip missing-required-key}")
+  (invalid! Animal {:age 3 :vegan? false :fav-catnip "cosmic" :type :dog}))
+
+(s/defschema TV
+  (abstract-map/open-abstract-map-schema
+   :make
+   {:channel s/Int
+    :power? s/Bool}))
+
+(abstract-map/extend-schema HondaTV TV [:honda] {:num-wheels s/Int})
+
+(deftest open-abstract-map-schema-test
+  (valid! TV {:channel 30 :power? true :num-wheels 1 :make :honda})
+  (valid! HondaTV {:channel 30 :power? true :num-wheels 1 :make :honda})
+  (valid! TV {:channel 30 :power? false :missiles "short range" :make :dod})
+  (invalid! TV {:channel 30 :make :unknown} "{:power? missing-required-key}"))
+
+(deftest json-coercer-test
+  (let [animal-coercer (coerce/coercer Animal coerce/json-coercion-matcher)
+        cat-coercer (coerce/coercer Cat coerce/json-coercion-matcher)
+        cat {:type :cat :age 12 :vegan? false :fav-catnip "cosmic"}]
+    (is (= cat (animal-coercer (update-in cat [:type] name))))
+    (is (= cat (cat-coercer (update-in cat [:type] name))))))


### PR DESCRIPTION
Proposal for internal implementation changes for Schema 1.0.  

Exposes internals of schemas in a more declarative way, simplifying implementation of new schema types and applications.  

Ultra-bare-bones experimental implementations of generation is included, but will be fleshed out before a release.  