### PR TITLE
introduces cond-pre to replace either

### DIFF
--- a/src/cljx/schema/spec/core.cljx
+++ b/src/cljx/schema/spec/core.cljx
@@ -34,8 +34,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Preconditions
 
-;; A Precondition is a function of a value that returns a ValidationError if the value
-;; does not satisfy the precondition, and otherwise returns nil.
+;; A Precondition is a function of a value that returns a
+;; ValidationError if the value does not satisfy the precondition,
+;; and otherwise returns nil.
 ;; e.g., (s/defschema Precondition (s/=> (s/maybe schema.utils.ValidationError) s/Any))
 ;; as such, a precondition is essentially a very simple checker.
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -282,13 +282,15 @@
            s/Int
            (s/maybe s/Str)
            (s/cond-pre s/Keyword {:x s/Int})
-           (s/both [s/Num] (s/pred (fn [xs] (even? (count xs))) 'even-len?)))]
+           (s/both [s/Num] (s/pred (fn [xs] (even? (count xs))) 'even-len?))
+           [s/Str])]
     (valid! s 1)
     (valid! s "hello")
     (valid! s nil)
     (valid! s :hello)
     (valid! s {:x 3})
     (valid! s [1 2])
+    (valid! s ["hello"])
     (invalid! s 3.14)
     (invalid! s [1 2 3])
     (invalid! s {:x 3.14})

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -277,6 +277,23 @@
       (is (= '(conditional odd? Int weird?)
              (s/explain (s/conditional odd? s/Int 'weird?)))))))
 
+(deftest cond-pre-test
+  (let [s (s/cond-pre
+           s/Int
+           (s/maybe s/Str)
+           (s/cond-pre s/Keyword {:x s/Int})
+           (s/both [s/Num] (s/pred (fn [xs] (even? (count xs))) 'even-len?)))]
+    (valid! s 1)
+    (valid! s "hello")
+    (valid! s nil)
+    (valid! s :hello)
+    (valid! s {:x 3})
+    (valid! s [1 2])
+    (invalid! s 3.14)
+    (invalid! s [1 2 3])
+    (invalid! s {:x 3.14})
+    (invalid! s [1 2 3])))
+
 (deftest if-test
   (let [schema (s/if #(= (:type %) :foo)
                  {:type (s/eq :foo) :baz s/Num}


### PR DESCRIPTION
s/cond-pre behaves like s/either, taking a list of schemas to match. But it is a little cleaner because it creates an s/conditional where the predicates are based on the schema spec preconditions.