### PR TITLE
make cond-pre have its own record

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -524,16 +524,26 @@
   (precondition [this]
     (complement (.-pre ^schema.spec.collection.CollectionSpec this))))
 
+(clojure.core/defrecord CondPre [schemas]
+  Schema
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     (for [s schemas]
+       {:guard (precondition (spec s))
+        :schema s})
+     #(list 'matches-some-precondition? %)))
+  (explain [this]
+    (cons 'cond-pre
+          (map explain schemas))))
+
 (clojure.core/defn cond-pre
   "A replacement for `either` that constructs a conditional schema
    based on the schema spec preconditions of the component schemas.
 
    EXPERIMENTAL"
   [& schemas]
-  (->> (for [s schemas]
-         [(precondition (spec s)) s])
-       (apply concat)
-       (apply conditional)))
+  (CondPre. schemas))
 
 ;;; both (satisfies this schema and that one)
 


### PR DESCRIPTION
This delays evaluation of the preconditions for cond-pre. Before, the preconditions were evaluated in the definition of the schema, which prevented recursive schemas from being defined. Now they will only be evaluated in the construction of the checker, which delays them enough for supporting recursive schemas.