### PR TITLE
Improve Explain for Primitive ClojureScript Schemas

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -185,13 +185,14 @@
   (explain [this]
     (if-let [more-schema (utils/class-schema this)]
       (explain more-schema)
-      #+clj (symbol (.getName ^Class this))
-      #+cljs (condp = this
-               js/Boolean 'Bool
-               js/Number 'Num
-               js/Date 'Inst
-               cljs.core/UUID 'Uuid
-               this))))
+      (condp = this
+        #+clj java.lang.String #+cljs nil 'Str
+        #+clj java.lang.Boolean #+cljs js/Boolean 'Bool
+        #+clj java.lang.Number #+cljs js/Number 'Num
+        #+clj java.util.regex.Pattern #+cljs nil 'Regex
+        #+clj java.util.Date #+cljs js/Date 'Inst
+        #+clj java.util.UUID #+cljs cljs.core/UUID 'Uuid
+        #+clj (symbol (.getName ^Class this)) #+cljs this))))
 
 
 ;; On the JVM, the primitive coercion functions (double, long, etc)

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -185,7 +185,13 @@
   (explain [this]
     (if-let [more-schema (utils/class-schema this)]
       (explain more-schema)
-      #+clj (symbol (.getName ^Class this)) #+cljs this)))
+      #+clj (symbol (.getName ^Class this))
+      #+cljs (condp = this
+               js/Boolean 'Bool
+               js/Number 'Num
+               js/Date 'Inst
+               cljs.core/UUID 'Uuid
+               this))))
 
 
 ;; On the JVM, the primitive coercion functions (double, long, etc)

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -161,7 +161,8 @@
 (deftest leaf-bool-test
   (valid! s/Bool true)
   (invalid! s/Bool nil "(not (instance? java.lang.Boolean nil))")
-  #+clj (is (= 'java.lang.Boolean (s/explain s/Bool))))
+  #+clj (is (= 'java.lang.Boolean (s/explain s/Bool)))
+  #+cljs (is (= 'Bool (s/explain s/Bool))))
 
 (deftest leaf-string-test
   (valid! s/Str "asdf")
@@ -175,7 +176,8 @@
   (valid! s/Num (/ 1 2))
   (invalid! s/Num nil "(not (instance? java.lang.Number nil))")
   (invalid! s/Num "1" "(not (instance? java.lang.Number \"1\"))")
-  #+clj (is (= 'java.lang.Number (s/explain s/Num))))
+  #+clj (is (= 'java.lang.Number (s/explain s/Num)))
+  #+cljs (is (= 'Num (s/explain s/Num))))
 
 (deftest leaf-int-test
   (valid! s/Int 1)
@@ -203,11 +205,13 @@
 
 (deftest leaf-inst-test
   (valid! s/Inst #inst "2013-01-01T01:15:01.840-00:00")
-  (invalid! s/Inst "2013-01-01T01:15:01.840-00:00"))
+  (invalid! s/Inst "2013-01-01T01:15:01.840-00:00")
+  #+cljs (is (= 'Inst (s/explain s/Inst))))
 
 (deftest leaf-uuid-test
   (valid! s/Uuid #uuid "0e98ce5b-9aca-4bf7-b5fd-d90576c80fdf")
-  (invalid! s/Uuid "0e98ce5b-9aca-4bf7-b5fd-d90576c80fdf"))
+  (invalid! s/Uuid "0e98ce5b-9aca-4bf7-b5fd-d90576c80fdf")
+  #+cljs (is (= 'Uuid (s/explain s/Uuid))))
 
 
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -56,8 +56,7 @@
   (deftest class-test
     (valid! String "a")
     (invalid! String nil "(not (instance? java.lang.String nil))")
-    (invalid! String :a "(not (instance? java.lang.String :a))")
-    (is (= 'java.lang.String (s/explain String))))
+    (invalid! String :a "(not (instance? java.lang.String :a))"))
 
   (deftest primitive-test
     (valid! double 1.0)
@@ -161,14 +160,13 @@
 (deftest leaf-bool-test
   (valid! s/Bool true)
   (invalid! s/Bool nil "(not (instance? java.lang.Boolean nil))")
-  #+clj (is (= 'java.lang.Boolean (s/explain s/Bool)))
-  #+cljs (is (= 'Bool (s/explain s/Bool))))
+  (is (= 'Bool (s/explain s/Bool))))
 
 (deftest leaf-string-test
   (valid! s/Str "asdf")
   (invalid! s/Str nil "(not (instance? java.lang.String nil))")
   (invalid! s/Str :a "(not (instance? java.lang.String :a))")
-  #+clj (is (= 'java.lang.String (s/explain s/Str))))
+  (is (= 'Str (s/explain s/Str))))
 
 (deftest leaf-number-test
   (valid! s/Num 1)
@@ -176,8 +174,7 @@
   (valid! s/Num (/ 1 2))
   (invalid! s/Num nil "(not (instance? java.lang.Number nil))")
   (invalid! s/Num "1" "(not (instance? java.lang.Number \"1\"))")
-  #+clj (is (= 'java.lang.Number (s/explain s/Num)))
-  #+cljs (is (= 'Num (s/explain s/Num))))
+  (is (= 'Num (s/explain s/Num))))
 
 (deftest leaf-int-test
   (valid! s/Int 1)
@@ -201,17 +198,18 @@
 
 (deftest leaf-regex-test
   (valid! s/Regex #".*")
-  (invalid! s/Regex ".*"))
+  (invalid! s/Regex ".*")
+  (is (= 'Regex (s/explain s/Regex))))
 
 (deftest leaf-inst-test
   (valid! s/Inst #inst "2013-01-01T01:15:01.840-00:00")
   (invalid! s/Inst "2013-01-01T01:15:01.840-00:00")
-  #+cljs (is (= 'Inst (s/explain s/Inst))))
+  (is (= 'Inst (s/explain s/Inst))))
 
 (deftest leaf-uuid-test
   (valid! s/Uuid #uuid "0e98ce5b-9aca-4bf7-b5fd-d90576c80fdf")
   (invalid! s/Uuid "0e98ce5b-9aca-4bf7-b5fd-d90576c80fdf")
-  #+cljs (is (= 'Uuid (s/explain s/Uuid))))
+  (is (= 'Uuid (s/explain s/Uuid))))
 
 
 


### PR DESCRIPTION
In particular under advanced compilation the schemas Bool, Num, Inst and
Uuid are not readable anymore.

We should discuss whether it's ok, that for example `Num` explains as `java.lang.Number` in Clojure and now `Num` in ClojureScript. Maybe it should explain as `js/Number` or both platforms should return `Num`. On the JVM, we have the class name. Is there a similar generic way in JavaScript? If there is a better way to explain leaf types in JavaScript, I would go for it instead of doing special things for the build-in leaf types.