### PR TITLE
Propagate return value of defn

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1215,20 +1215,21 @@
         {:keys [doc tag] :as standard-meta} (meta name)
         {:keys [outer-bindings schema-form fn-body arglists raw-arglists]} (macros/process-fn- &env name more-defn-args)]
     `(let ~outer-bindings
-       (clojure.core/defn ~(with-meta name {})
-         ~(assoc (apply dissoc standard-meta (when (macros/primitive-sym? tag) [:tag]))
-            :doc (str
-                  (str "Inputs: " (if (= 1 (count raw-arglists))
-                                    (first raw-arglists)
-                                    (apply list raw-arglists)))
-                  (when-let [ret (when (= (second defn-args) :-) (nth defn-args 2))]
-                    (str "\n  Returns: " ret))
-                  (when doc (str  "\n\n  " doc)))
-            :raw-arglists (list 'quote raw-arglists)
-            :arglists (list 'quote arglists)
-            :schema schema-form)
-         ~@fn-body)
-       (utils/declare-class-schema! (utils/fn-schema-bearer ~name) ~schema-form))))
+       (let [ret# (clojure.core/defn ~(with-meta name {})
+                    ~(assoc (apply dissoc standard-meta (when (macros/primitive-sym? tag) [:tag]))
+                       :doc (str
+                             (str "Inputs: " (if (= 1 (count raw-arglists))
+                                               (first raw-arglists)
+                                               (apply list raw-arglists)))
+                             (when-let [ret (when (= (second defn-args) :-) (nth defn-args 2))]
+                               (str "\n  Returns: " ret))
+                             (when doc (str  "\n\n  " doc)))
+                       :raw-arglists (list 'quote raw-arglists)
+                       :arglists (list 'quote arglists)
+                       :schema schema-form)
+                    ~@fn-body)]
+         (utils/declare-class-schema! (utils/fn-schema-bearer ~name) ~schema-form)
+         ret#))))
 
 (defmacro defmethod
   "Like clojure.core/defmethod, except that schema-style typehints can be given on

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1026,6 +1026,13 @@
 
 (def ^String +bad-input-str+ "Input to simple-validated-defn does not match schema")
 
+;; Test that s/defn returns var
+#+clj
+(with-test
+  (s/defn with-test-fn [a b] (+ a b))
+  (is (= 3 (with-test-fn 1 2)))
+  (is (= 0 (with-test-fn 10 -10))))
+
 #+cljs
 (deftest simple-validated-defn-test
   (s/with-fn-validation


### PR DESCRIPTION
Match the return value of `schema.core/defn` with `clojure.core/defn`

Note: `let` the value rather than simply returning `(var ~name)` because some
versions of ClojureScript do not support vars.

Fixes #274