### PR TITLE
Add 'coercer!' which throws on errors (fixes #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.2
  * Extend keyword `enum` coercion to keyword `eq` coercion
  * Add `s/atom` schema for atoms
+ * Add `coercer!` which throws on error
  * Add leaf generators for UUIDs
  * Make `s/defn` compatible with `with-test` 
 

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -73,6 +73,11 @@
             (is (= res (coercer {:jb "false" :l "2.0" :d "1" :jk "asdf"})))
             (is (= #{:l} (err-ks (coercer {:l "1.2"})))))))
 
+(deftest coercer!-test
+  (let [coercer (coerce/coercer! {:k s/Keyword :i s/Int} coerce/string-coercion-matcher)]
+    (is (= {:k :key :i 12} (coercer {:k "key" :i "12"})))
+    (is (thrown-with-msg? #+clj Exception #+cljs js/Error  #"keyword\? 12" (coercer {:k 12 :i 12})))))
+
 #+clj
 (do
   (def NestedVecs


### PR DESCRIPTION
It was a bit confusing that `coercer` required you to separate errors yourself.   Provides a new version which throws on errors and only returns successfully coerced values.