### PR TITLE
Add atom schema (fixes #186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.2
  * Extend keyword `enum` coercion to keyword `eq` coercion
+ * Add `s/atom` schema for atoms
  * Add leaf generators for UUIDs
  * Make `s/defn` compatible with `with-test` 
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -365,6 +365,15 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Atom schemas
+
+(deftest atom-test
+  (let [s (s/atom s/Str)]
+    (is (not (s/check s (atom "asdf")))) ;; don't expect identity after walking
+    (invalid! s (delay "asdf") "(not (atom? a-clojure.lang.Delay))")
+    (invalid! s (atom 1))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Map Schemas
 
 (deftest uniform-map-test


### PR DESCRIPTION
Despite conversation over in #186 about making a generalized `reference` schema, after some further thought I agreed with the OP and decided to just add `atom` for now.  In particular, the tricky bit about adding a generic `reference` comes with coercion and generation, where you really need a concrete reference type to deal with. 