### PR TITLE
Clarify behavior of primitive type hints in s/defn (fixes #264, closes #270)

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1197,6 +1197,11 @@
       means that all arities must share the same output schema. Schema will
       automatically propagate primitive hints to the arg vector and class hints
       to the fn name, so that you get the behavior you expect from Clojure.
+    - All primitive schemas will be passed through as type hints to Clojure,
+      despite their legality in a particular position.  E.g.,
+        (s/defn foo [x :- int])
+      will fail because Clojure does not allow primitive ints as fn arguments;
+      in such cases, use the boxed Classes instead (e.g., Integer).
     - Schema metadata is only processed on top-level arguments.  I.e., you can
       use destructuring, but you must put schema metadata on the top-level
       arguments, not the destructured variables.


### PR DESCRIPTION
As discussed in the linked tickets, all primitives are potentially valid type hints in Clojure.  

Since in principle schemas aren't limited just to function arguments, it doesn't seem correct to limit the handling of primitives to just where they are allowed in function arguments.  Instead, I think it's better to just make the user aware that they should only use the primitive schemas where they would normally be appropriate in Clojure, and otherwise used boxed versions (the same way you would with, e.g. type hints on an ordinary `defn`.)   This PR updates the docs accordingly.