### PR TITLE
Add constrained schema with postconditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * Add `coercer!` which throws on error
  * Add leaf generators for UUIDs
  * Make `s/defn` compatible with `with-test` 
+ * Add `constrained` schema for postconditions (replaces `(both x (s/pred ...))`)
 
 ## 1.0.1
  * Catch and report exceptions in guards the same as preconditions, rather than allowing them to propagate out.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Similarly, you can also write sequence schemas that expect particular values in 
 
 ### Other schema types
 
-[`schema.core`](https://github.com/Prismatic/schema/blob/master/src/cljx/schema/core.cljx) provides many more utilities for building schemas, including `maybe`, `eq`, `enum`, `pred`, `conditional`, `cond-pre`, and more.  Here are a few of our favorites:
+[`schema.core`](https://github.com/Prismatic/schema/blob/master/src/cljx/schema/core.cljx) provides many more utilities for building schemas, including `maybe`, `eq`, `enum`, `pred`, `conditional`, `cond-pre`, `constrained`, and more.  Here are a few of our favorites:
 
 ```clojure
 ;; anything
@@ -297,8 +297,11 @@ Similarly, you can also write sequence schemas that expect particular values in 
 ;; will be chosen based on the `map?` precondition (use `if` or `abstract-map-schema` instead):
 (def BadSchema (s/cond-pre {:a s/Keyword} {:b s/Keyword}))
 
-;; conditional can also be used to apply extra validation to a single type
-(def OddLong (s/conditional odd? long))
+;; conditional can also be used to apply extra validation to a single type,
+;; but constrained is often more desirable since it applies the validation
+;; as a *postcondition*, which typically provides better error messages
+;; and works better with coercion
+(def OddLong (s/constrained long odd?))
 (s/validate OddLong 1)
 ;; 1
 (s/validate OddLong 2)

--- a/src/clj/schema/experimental/generators.clj
+++ b/src/clj/schema/experimental/generators.clj
@@ -37,7 +37,12 @@
   schema.spec.variant.VariantSpec
   (composite-generator [s params]
     (generators/such-that
-     (complement (.-pre ^schema.spec.variant.VariantSpec s))
+     (fn [x]
+       (let [pre (.-pre ^schema.spec.variant.VariantSpec s)
+             post (.-post ^schema.spec.variant.VariantSpec s)]
+         (not
+          (or (pre x)
+              (and post (post x))))))
      (generators/one-of
       (for [o (macros/safe-get s :options)]
         (if-let [g (:guard o)]

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -88,3 +88,7 @@
     (is (= [1 [2 [3] [4]]]
            ((coerce/coercer NestedVecs coerce/string-coercion-matcher)
             ["1" ["2" ["3"] ["4"]]])))))
+
+(deftest constrained-test
+  (let [coercer (coerce/coercer! (s/constrained s/Int odd?) coerce/string-coercion-matcher)]
+    (is (= 1 (coercer "1")))))

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -299,6 +299,15 @@
     (invalid! s {:x 3.14})
     (invalid! s [1 2 3])))
 
+(deftest constrained-test
+  (let [s (s/constrained s/Int odd?)]
+    (is (= '(constrained Int odd?) (s/explain s)))
+    (valid! s 1)
+    (valid! s 5)
+    (invalid! s 2 "(not (odd? 2))")
+    (invalid! s "2" "(not (integer? \"2\"))")
+    (invalid! (s/constrained s/Str odd?) "2" "(throws? (odd? \"2\"))" )))
+
 (deftest if-test
   (let [schema (s/if #(= (:type %) :foo)
                  {:type (s/eq :foo) :baz s/Num}


### PR DESCRIPTION
Solves the error message and coercion issues people were seeing after moving from `(s/both s (s/pred ...))` to `conditional`.  

Fixes #291 and #269 