### PR TITLE
Upgrade test.check, start using fancier generators

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "0.0-2760"]
                                   [org.clojure/tools.nrepl "0.2.5"]
-                                  [org.clojure/test.check "0.8.0"]
+                                  [org.clojure/test.check "0.9.0"]
                                   [potemkin "0.4.1"]]
                    :plugins [[com.keminglabs/cljx "0.6.0" :exclusions [org.clojure/clojure]]
                              [codox "0.8.8"]


### PR DESCRIPTION
The biggest change here is that the numeric generators will now generate
a much larger range of numbers, which could be bad for anybody who was
relying on the default -200→200 range.

The tests are currently failing because apparently the infinite doubles can't be trivially cast to infinite floats, but that could be fixed with a bit of fiddling, once somebody confirms that these changes are otherwise acceptable.