### PR TITLE
Better performance for anonymous schematized functions, via lazy checker creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.4
  * Update generators, bump minimum version of test.check to 0.9.0.  Generators will only work under Clojure 1.7.0+.
+ * Better performance for anonymous schematized functions, via lazy checker creation
 
 ## 1.0.3
  * Fix warning about overriding `atom` under Clojure 1.7


### PR DESCRIPTION
Fixes https://github.com/Prismatic/plumbing/issues/92

Unfortunately I don't know of a way to hoist the schema checker creation for anonymous functions, so it was happening on every creation instance.  This PR adds a delay around checker creation (and makes another small optimization), making it about 20 times faster to create anonymous functions (or `fnks`) than previously.  Should also speed up load time for schematized codebases slightly.  