### PR TITLE
Update changelog and project.clj to reflect new generator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+ * Update generators, bump minimum version of test.check to 0.9.0.  Generators will only work under Clojure 1.7.0+.
+
 ## 1.0.3
  * Fix warning about overriding `atom` under Clojure 1.7
  * Fix behavior of `constrained` with some schemas (e.g. maps).

--- a/project.clj
+++ b/project.clj
@@ -25,10 +25,9 @@
                                    {:source-paths ["test/cljx"]
                                     :output-path "target/generated/test/cljs"
                                     :rules :cljs}]}}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC1"] [org.clojure/clojurescript "0.0-3308"]]}}
 
-  :aliases {"all" ["with-profile" "dev:dev,1.6:dev,1.8"]
+  :aliases {"all" ["with-profile" "dev:dev,1.8"]
             "deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]
             "test" ["do" "clean," "cljx" "once," "test," "with-profile" "dev" "cljsbuild" "test"]}
 


### PR DESCRIPTION
Everything (except generators) should still work fine under 1.6, but I think it would require some fancy footwork to keep running the tests under 1.6, so I just removed it for now.  Thoughts?  