### PR TITLE
Move typehint off use-fn-validation var to hopefully fix AOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.0.4
+ * Attempt to resolve issues with AOT compilation by moving typehint on `use-fn-validation` var to callsites.
  * Update generators, bump minimum version of test.check to 0.9.0.  Generators will only work under Clojure 1.7.0+.
  * Better performance for anonymous schematized functions, via lazy checker creation
 

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -264,7 +264,7 @@
         fn-forms (map :arity-form processed-arities)]
     {:outer-bindings (vec (concat
                            (when compile-validation
-                             `[^schema.utils.PSimpleCell ~'ufv__ schema.utils/use-fn-validation])
+                             `[~(with-meta 'ufv__ {:tag 'schema.utils.PSimpleCell}) schema.utils/use-fn-validation])
                            [output-schema-sym output-schema]
                            (apply concat schema-bindings)
                            (mapcat :more-bindings processed-arities)))

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1143,12 +1143,12 @@
 (clojure.core/defn fn-validation?
   "Get the current global schema validation setting."
   []
-  (.get_cell utils/use-fn-validation))
+  (.get_cell ^schema.utils.PSimpleCell utils/use-fn-validation))
 
 (clojure.core/defn set-fn-validation!
   "Globally turn on (or off) schema validation for all s/fn and s/defn instances."
   [on?]
-  (.set_cell utils/use-fn-validation on?))
+  (.set_cell ^schema.utils.PSimpleCell utils/use-fn-validation on?))
 
 (defmacro with-fn-validation
   "Execute body with input and output schema validation turned on for

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -181,7 +181,7 @@
   (get_cell [this] q)
   (set_cell [this x] (set! q x)))
 
-(def ^schema.utils.PSimpleCell use-fn-validation
+(def use-fn-validation
   "Turn on run-time function validation for functions compiled when
    s/compile-fn-validation was true -- has no effect for functions compiled
    when it is false."


### PR DESCRIPTION
See #236.  The typehint is necessary for performance, but if it fixes AOT we can move it to the call sites.  (Also fixes an old incorrect hint on the hot call site, after which perf seems unchanged).