### PR TITLE
Fix completion through non-map collections (fixes #325)

### DIFF
--- a/src/clj/schema/experimental/complete.clj
+++ b/src/clj/schema/experimental/complete.clj
@@ -52,7 +52,11 @@
                                             (map s/explicit-schema-key))))]
               (sub-checker
                (into {} (for [k ks] [k (get x k +missing+)])))))))
-      (fn [x] (assert (not= x +missing+)) (sub-checker x))))
+      (let [g (apply generators/generator s generator-opts)]
+        (fn coll-completer [x]
+          (if (= +missing+ x)
+            (sample g)
+            (sub-checker x))))))
 
   schema.spec.leaf.LeafSpec
   (completer* [spec s sub-checker generator-opts]

--- a/test/clj/schema/experimental/complete_test.clj
+++ b/test/clj/schema/experimental/complete_test.clj
@@ -7,11 +7,12 @@
    [schema.experimental.complete :as complete]))
 
 (deftest complete-test
-  (let [s [{:a s/Int :b s/Str}]
-        [r1 r2 :as rs] (complete/complete [{:a 1} {:b "bob"}] s)]
+  (let [s [{:a s/Int :b s/Str :c [s/Str]}]
+        [r1 r2 r3 :as rs] (complete/complete [{:a 1} {:b "bob"} {:c ["foo" "bar"]}] s)]
     (is (not (s/check s rs)))
     (is (= (:a r1) 1))
-    (is (= (:b r2) "bob")))
+    (is (= (:b r2) "bob"))
+    (is (= (:c r3) ["foo" "bar"])))
   (testing "complete through variant"
     (let [s (s/cond-pre s/Str {:foo s/Int})]
       (is (= "test" (complete/complete "test" s)))


### PR DESCRIPTION
While we still don't have a plugabble way to e.g. extend a partial collection to a valid one, this fixes the bug pointed out in #325.